### PR TITLE
Auto-generate database

### DIFF
--- a/.github/workflows/gen-db.yml
+++ b/.github/workflows/gen-db.yml
@@ -5,7 +5,11 @@
 name: Generate Database
 
 on:
+  # More details on trigger events: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
   workflow_dispatch:  # manual execution
+  pull_request:
+    types: [ closed ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/gen-db.yml
+++ b/.github/workflows/gen-db.yml
@@ -1,4 +1,6 @@
-# This workflow will install Python dependencies, run the python script to generate the database, and upload the regenerated database
+# This workflow will install Python dependencies,
+# run the python script to generate the database,
+# and upload the regenerated database to the binary repo
 
 name: Generate Database
 
@@ -26,9 +28,16 @@ jobs:
     - name: Generate database
       run: |
         python scripts/tutorials/generate_database.py
-        git config user.name github-actions
-        git config user.email github-actions@github.com
-        git add SIMPLE.db
-        git commit -m "auto regenerating database"
-        git push
       working-directory: .
+
+    - name: Push database file
+      uses: dmnemec/copy_file_to_another_repo_action@main
+      # Details for this action at https://github.com/marketplace/actions/push-a-file-to-another-repository
+      env:
+          API_TOKEN_GITHUB: ${{ secrets.SIMPLE_TOKEN }}
+      with:
+          source_file: 'SIMPLE.db'
+          destination_repo: 'SIMPLE-AstroDB/SIMPLE-binary'
+          destination_branch: 'main'
+          user_email: 'github-actions@github.com'
+          user_name: 'github-actions'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore the database file
+SIMPLE.db


### PR DESCRIPTION
This update re-enables the Github Action to generate the database for closed pull requests. The binary file is then pushed to a new repo just for it: https://github.com/SIMPLE-AstroDB/SIMPLE-binary 
This can also be run manually from the Actions page and we can update it to set it on a schedule.

I've also added a .gitignore file that lists the binary database file so we can avoid pushing changes to it. At some point later we will want to explicitly remove it from the repo entirely.