### PR TITLE
Change to testing adopted column

### DIFF
--- a/scripts/ingests/utils.py
+++ b/scripts/ingests/utils.py
@@ -132,7 +132,7 @@ def ingest_parallaxes(db, sources, plx, plx_unc, plx_ref, verbose=False, norun=F
     n_added = 0
 
     for i, source in enumerate(sources):
-        db_name = db.search_object(source, output_table='Sources')[0].source
+        db_name = db.search_object(source, output_table='Sources')[0]['source']
 
         # Search for existing parallax data and determine if this is the best
         adopted = None

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -225,11 +225,11 @@ def test_parallaxes(db):
     # Tests against the Parallaxes table
 
     # While there may be many parallax measurements for a single source,
-    # there should be one and only one marked as adopted
+    # there should be only one marked as adopted
     t = db.query(db.Parallaxes.c.source,
                  func.sum(db.Parallaxes.c.adopted).label('adopted_counts')). \
         group_by(db.Parallaxes.c.source). \
-        having(func.sum(db.Parallaxes.c.adopted) != 1). \
+        having(func.sum(db.Parallaxes.c.adopted) > 1). \
         astropy()
     if len(t) > 0:
         print("\nParallax entries with incorrect 'adopted' labels")
@@ -286,11 +286,11 @@ def test_spectraltypes(db):
     assert len(t) == 0
 
     # While there may be many spectral type measurements for a single source,
-    # there should be one and only one marked as adopted
+    # there should be only one marked as adopted
     t = db.query(db.SpectralTypes.c.source,
                  func.sum(db.SpectralTypes.c.adopted).label('adopted_counts')). \
         group_by(db.SpectralTypes.c.source). \
-        having(func.sum(db.SpectralTypes.c.adopted) != 1). \
+        having(func.sum(db.SpectralTypes.c.adopted) > 1). \
         astropy()
     if len(t) > 0:
         print("\nSpectral Type entries with incorrect 'adopted' labels")


### PR DESCRIPTION
Relevant to #84, I've updated the tests so they only verify that adopted is set at most once per source. Null or empty values should not trigger failures.