### PR TITLE
Logger improvements

### DIFF
--- a/scripts/ingests/utils.py
+++ b/scripts/ingests/utils.py
@@ -25,7 +25,7 @@ logger = logging.getLogger('SIMPLE')
 # Logger setup
 # This will stream all logger messages to the standard output and apply formatting for that
 logger.propagate = False  # prevents duplicated logging messages
-LOGFORMAT = logging.Formatter('%(asctime)s %(levelname)s:%(message)s', datefmt='%m/%d/%Y %I:%M:%S %p')
+LOGFORMAT = logging.Formatter('%(asctime)s %(levelname)s: %(message)s', datefmt='%m/%d/%Y %I:%M:%S%p')
 ch = logging.StreamHandler(stream=sys.stdout)
 ch.setFormatter(LOGFORMAT)
 # To prevent duplicate handlers, only add if they haven't been set previously


### PR DESCRIPTION
Adding an explicit logger handler to control the format and send to standard output like a normal print statement; default logging statements can sometimes be going to standard error (`sys.stderr`) which some applications hide/ignore or color differently.