### PR TITLE
Publication table update script and schema update

### DIFF
--- a/data/2mass_j09510549+3558021.json
+++ b/data/2mass_j09510549+3558021.json
@@ -34,7 +34,7 @@
             "parallax_error": 2.8,
             "adopted": true,
             "comments": null,
-            "reference": "Liu16"
+            "reference": "Liu_16"
         }
     ],
     "Photometry": [

--- a/data/Publications.json
+++ b/data/Publications.json
@@ -1,6522 +1,6522 @@
 [
     {
-        "name": "Schm10.1808",
+        "publication": "Schm10.1808",
         "bibcode": "2010AJ....139.1808S",
         "doi": "10.1088/0004-6256/139/5/1808",
         "description": "Colors and Kinematics of L Dwarfs From the Sloan Digital Sky Survey"
     },
     {
-        "name": "Cutr12",
+        "publication": "Cutr12",
         "bibcode": "2012yCat.2311....0C",
         "doi": null,
         "description": "WISE All-Sky Data Release"
     },
     {
-        "name": "Cutr03",
+        "publication": "Cutr03",
         "bibcode": "2003tmc..book.....C",
         "doi": null,
         "description": "2MASS All Sky Catalog of point sources"
     },
     {
-        "name": "Alle09",
+        "publication": "Alle09",
         "bibcode": "2009ApJ...697..824A",
         "doi": "10.1088/0004-637X/697/1/824",
         "description": "2MASS 22344161+4041387AB: A Wide, Young, Accreting, Low-Mass Binary in the LkHa233 Group"
     },
     {
-        "name": "Alle10",
+        "publication": "Alle10",
         "bibcode": "2010ApJ...715..561A",
         "doi": "10.1088/0004-637X/715/1/561",
         "description": "Discovery of A Young L Dwarf Binary, SDSS J224953.47+004404.6AB"
     },
     {
-        "name": "Andr11",
+        "publication": "Andr11",
         "bibcode": "2011AJ....141...54A",
         "doi": "10.1088/0004-6256/141/2/54",
         "description": "Parallaxes of Southern Extremely Cool Objects. I. Targets, Proper Motions, and First Results"
     },
     {
-        "name": "Arti10",
+        "publication": "Arti10",
         "bibcode": "2010ApJ...718L..38A",
         "doi": "10.1088/2041-8205/718/1/L38",
         "description": "DENIS J081730.0-615520: An Overlooked Mid-T Dwarf in the Solar Neighborhood"
     },
     {
-        "name": "Bene99",
+        "publication": "Bene99",
         "bibcode": "1999AJ....118.1086B",
         "doi": "10.1086/300975",
         "description": "Interferometric Astrometry of Proxima Centauri and Barnard's Star Using HUBBLE SPACE TELESCOPE Fine Guidance Sensor 3: Detection Limits for Substellar Companions"
     },
     {
-        "name": "Bern10",
+        "publication": "Bern10",
         "bibcode": "2010ApJ...715..724B",
         "doi": "10.1088/0004-637X/715/2/724",
         "description": "A Close Companion Search Around L Dwarfs Using Aperture Masking Interferometry and Palomar Laser Guide Star Adaptive Optics"
     },
     {
-        "name": "Bill06a",
+        "publication": "Bill06a",
         "bibcode": "2006ApJ...641L.141B",
         "doi": "10.1086/504256",
         "description": "Discovery of a Brown Dwarf Very Close to the Sun: A Methane-rich Brown Dwarf Companion to the Low-Mass Star SCR 1845-6357"
     },
     {
-        "name": "Bill10",
+        "publication": "Bill10",
         "bibcode": "2010ApJ...720L..82B",
         "doi": "10.1088/2041-8205/720/1/L82",
         "description": "The Gemini NICI Planet-finding Campaign: Discovery of a Close Substellar Companion to the Young Debris Disk Star PZ Tel"
     },
     {
-        "name": "Bocc03b",
+        "publication": "Bocc03b",
         "bibcode": "2003A&A...410..283B",
         "doi": "10.1051/0004-6361:20031216",
         "description": "Near-IR coronagraphic imaging of the companion to HR 7672"
     },
     {
-        "name": "Bonn11",
+        "publication": "Bonn11",
         "bibcode": "2011A&A...528L..15B",
         "doi": "10.1051/0004-6361/201016224",
         "description": "High angular resolution detection of beta Pictoris b at 2.18 \u03bcm"
     },
     {
-        "name": "Bouv08a",
+        "publication": "Bouv08a",
         "bibcode": "2008A&A...481..661B",
         "doi": "10.1051/0004-6361:20079303",
         "description": "Brown dwarfs and very low mass stars in the Hyades cluster: a dynamically evolved mass function"
     },
     {
-        "name": "Bouy03",
+        "publication": "Bouy03",
         "bibcode": "2003AJ....126.1526B",
         "doi": "10.1086/377343",
         "description": "Multiplicity of Nearby Free-Floating Ultracool Dwarfs: A Hubble Space Telescope WFPC2 Search for Companions"
     },
     {
-        "name": "Bouy04a",
+        "publication": "Bouy04a",
         "bibcode": "2004A&A...423..341B",
         "doi": "10.1051/0004-6361:20040551",
         "description": "First determination of the dynamical mass of a binary L dwarf"
     },
     {
-        "name": "Bouy05",
+        "publication": "Bouy05",
         "bibcode": "2005AJ....129..511B",
         "doi": "10.1086/426559",
         "description": "A Possible Third Component in the L Dwarf Binary System DENIS-P J020529.0-115925 Discovered with the Hubble Space Telescope"
     },
     {
-        "name": "Bouy08b",
+        "publication": "Bouy08b",
         "bibcode": "2008A&A...481..757B",
         "doi": "10.1051/0004-6361:20078803",
         "description": "Follow-up observations of binary ultra-cool dwarfs"
     },
     {
-        "name": "Bouy11",
+        "publication": "Bouy11",
         "bibcode": "2011A&A...526A..55B",
         "doi": "10.1051/0004-6361/201015289",
         "description": "Adaptive optics observations of the T10 ultracool dwarf UGPS J072227.51-054031.2"
     },
     {
-        "name": "Bran04",
+        "publication": "Bran04",
         "bibcode": "2004A&A...428..205B",
         "doi": "10.1051/0004-6361:20041912",
         "description": "Astrometric monitoring of the binary brown dwarf DENIS-P J1228.2-1547"
     },
     {
-        "name": "Bowl09",
+        "publication": "Bowl09",
         "bibcode": "2009ApJ...706.1114B",
         "doi": "10.1088/0004-637X/706/2/1114",
         "description": "The Benchmark Ultracool Subdwarf HD 114762B: A Test of Low-metallicity Atmospheric and Evolutionary Models"
     },
     {
-        "name": "Bowl10a",
+        "publication": "Bowl10a",
         "bibcode": "2010ApJ...710...45B",
         "doi": "10.1088/0004-637X/710/1/45",
         "description": "SDSS J141624.08+134826.7: A Nearby Blue L Dwarf From the Sloan Digital Sky Survey"
     },
     {
-        "name": "Burg00a",
+        "publication": "Burg00a",
         "bibcode": "2000ApJ...531L..57B",
         "doi": "10.1086/312522",
         "description": "Discovery of a brown dwarf companion to Gliese 570ABC: a 2MASS T dwarf significantly cooler than Gliese 229B"
     },
     {
-        "name": "Burg03d",
+        "publication": "Burg03d",
         "bibcode": "2003ApJ...594..510B",
         "doi": "10.1086/376756",
         "description": "The spectra of T dwarfs. II. Red optical data"
     },
     {
-        "name": "Burg03b",
+        "publication": "Burg03b",
         "bibcode": "2003ApJ...586..512B",
         "doi": "10.1086/346263",
         "description": "Binarity in Brown Dwarfs: T Dwarf Binaries Discovered with the Hubble Space Telescope Wide Field Planetary Camera 2"
     },
     {
-        "name": "Burg03c",
+        "publication": "Burg03c",
         "bibcode": "2003ApJ...592.1186B",
         "doi": "10.1086/375813",
         "description": "The First Substellar Subdwarf? Discovery of a Metal-poor L Dwarf with Halo Kinematics"
     },
     {
-        "name": "Burg04c",
+        "publication": "Burg04c",
         "bibcode": "2004ApJ...614L..73B",
         "doi": "10.1086/425418",
         "description": "Discovery of a Second L Subdwarf in the Two Micron All Sky Survey"
     },
     {
-        "name": "Burg05a",
+        "publication": "Burg05a",
         "bibcode": "2005AJ....129.2849B",
         "doi": "10.1086/430218",
         "description": "Multiplicity among Widely Separated Brown Dwarf Companions to Nearby Stars: Gliese 337CD"
     },
     {
-        "name": "Burg05c",
+        "publication": "Burg05c",
         "bibcode": "2005ApJ...634L.177B",
         "doi": "10.1086/498866",
         "description": "SDSS J042348.57-041403.5AB: A Brown Dwarf Binary Straddling the L/T Transition"
     },
     {
-        "name": "Burg06c",
+        "publication": "Burg06c",
         "bibcode": "2006ApJ...639.1095B",
         "doi": "10.1086/499344",
         "description": "A Method for Determining the Physical Properties of the Coldest Known Brown Dwarfs"
     },
     {
-        "name": "Burg06e",
+        "publication": "Burg06e",
         "bibcode": "2006ApJS..166..585B",
         "doi": "10.1086/506327",
         "description": "Hubble Space Telescope NICMOS Observations of T Dwarfs: Brown Dwarf Multiplicity and New Probes of the L/T Transition"
     },
     {
-        "name": "Burg07a",
+        "publication": "Burg07a",
         "bibcode": "2007ApJ...657..494B",
         "doi": "10.1086/510148",
         "description": "Optical Spectroscopy of 2MASS Color-selected Ultracool Subdwarfs"
     },
     {
-        "name": "Burg07e",
+        "publication": "Burg07e",
         "bibcode": "2007AJ....134.1330B",
         "doi": "10.1086/520878",
         "description": "SDSS J080531.84+481233.0: An Unresolved L Dwarf/T Dwarf Binary"
     },
     {
-        "name": "Burg08d",
+        "publication": "Burg08d",
         "bibcode": "2008ApJ...681..579B",
         "doi": "10.1086/588379",
         "description": "Subtle Signatures of Multiplicity in Late-type Dwarf Spectra: The Unresolved M8.5 + T5 Binary 2MASS J03202839-0446358"
     },
     {
-        "name": "Burg08b",
+        "publication": "Burg08b",
         "bibcode": "2008ApJ...689L..53B",
         "doi": "10.1086/595747",
         "description": "2MASS J09393548-2448279: The Coldest and Least Luminous Brown Dwarf Binary Known?"
     },
     {
-        "name": "Burg08a",
+        "publication": "Burg08a",
         "bibcode": "2008ApJ...672.1159B",
         "doi": "10.1086/523810",
         "description": "Parallax and Luminosity Measurements of an L Subdwarf"
     },
     {
-        "name": "Burg09a",
+        "publication": "Burg09a",
         "bibcode": "2009ApJ...697..148B",
         "doi": "10.1088/0004-637X/697/1/148",
         "description": "Optical and Near-Infrared Spectroscopy of the L Subdwarf SDSS J125637.13-022452.4"
     },
     {
-        "name": "Burg10c",
+        "publication": "Burg10c",
         "bibcode": "2010ApJ...725.1405B",
         "doi": "10.1088/0004-637X/725/2/1405",
         "description": "Clouds in the Coldest Brown Dwarfs: Fire Spectroscopy of Ross 458C"
     },
     {
-        "name": "Burg11a",
+        "publication": "Burg11a",
         "bibcode": "2011AJ....141...70B",
         "doi": "10.1088/0004-6256/141/3/70",
         "description": "Hubble Space Telescope Imaging and Spectral Analysis of Two Brown Dwarf Binaries at the L Dwarf/T Dwarf Transition"
     },
     {
-        "name": "Burg11b",
+        "publication": "Burg11b",
         "bibcode": "2011ApJ...735..116B",
         "doi": "10.1088/0004-637X/735/2/116",
         "description": "Fire Spectroscopy of Five Late-type T Dwarfs Discovered with the Wide-field Infrared Survey Explorer"
     },
     {
-        "name": "Burn08",
+        "publication": "Burn08",
         "bibcode": "2008MNRAS.391..320B",
         "doi": "10.1111/j.1365-2966.2008.13885.x",
         "description": "Exploring the substellar temperature regime down to \\~{}550K"
     },
     {
-        "name": "Burn09",
+        "publication": "Burn09",
         "bibcode": "2009MNRAS.395.1237B",
         "doi": "10.1111/j.1365-2966.2009.14620.x",
         "description": "The discovery of an M4+T8.5 binary system"
     },
     {
-        "name": "Burn10",
+        "publication": "Burn10",
         "bibcode": "2010MNRAS.404.1952B",
         "doi": "10.1111/j.1365-2966.2010.16411.x",
         "description": "The discovery of a very cool binary system"
     },
     {
-        "name": "Chau04",
+        "publication": "Chau04",
         "bibcode": "2004A&A...425L..29C",
         "doi": "10.1051/0004-6361:200400056",
         "description": "A giant planet candidate near a young brown dwarf. Direct VLT/NACO observations using IR wavefront sensing"
     },
     {
-        "name": "Chau05",
+        "publication": "Chau05",
         "bibcode": "2005A&A...438L..29C",
         "doi": "10.1051/0004-6361:200500111",
         "description": "A companion to AB Pic at the planet/brown dwarf boundary"
     },
     {
-        "name": "Chau10",
+        "publication": "Chau10",
         "bibcode": "2010A&A...509A..52C",
         "doi": "10.1051/0004-6361/200911716",
         "description": "Deep imaging survey of young, nearby austral stars . VLT/NACO near-infrared Lyot-coronographic observations"
     },
     {
-        "name": "Chiu06",
+        "publication": "Chiu06",
         "bibcode": "2006AJ....131.2722C",
         "doi": "10.1086/501431",
         "description": "Seventy-One New L and T Dwarfs from the Sloan Digital Sky Survey"
     },
     {
-        "name": "Clos02",
+        "publication": "Clos02",
         "bibcode": "2002ApJ...567L..53C",
         "doi": "10.1086/339795",
         "description": "An Adaptive Optics Survey of M8-M9 Stars: Discovery of Four Very Low Mass Binaries with at Least One System Containing a Brown Dwarf Companion"
     },
     {
-        "name": "Clos03",
+        "publication": "Clos03",
         "bibcode": "2003ApJ...587..407C",
         "doi": "10.1086/368177",
         "description": "Detection of Nine M8.0-L0.5 Binaries: The Very Low Mass Binary Population and Its Implications for Brown Dwarf and Very Low Mass Star Formation"
     },
     {
-        "name": "Cost05",
+        "publication": "Cost05",
         "bibcode": "2005AJ....130..337C",
         "doi": "10.1086/430473",
         "description": "The Solar Neighborhood. XIV. Parallaxes from the Cerro Tololo Inter-American Observatory Parallax Investigation-First Results from the 1.5 m Telescope Program"
     },
     {
-        "name": "Cost06",
+        "publication": "Cost06",
         "bibcode": "2006AJ....132.1234C",
         "doi": "10.1086/505706",
         "description": "The Solar Neighborhood. XVI. Parallaxes from CTIOPI: Final Results from the 1.5 m Telescope Program"
     },
     {
-        "name": "Crif05",
+        "publication": "Crif05",
         "bibcode": "2005A&A...441..653C",
         "doi": "10.1051/0004-6361:20052998",
         "description": "New neighbours. VI. Spectroscopy of DENIS nearby stars candidates"
     },
     {
-        "name": "Cruz03",
+        "publication": "Cruz03",
         "bibcode": "2003AJ....126.2421C",
         "doi": "10.1086/378607",
         "description": "Meeting the Cool Neighbors. V. A 2MASS-Selected Sample of Ultracool Dwarfs"
     },
     {
-        "name": "Cruz07",
+        "publication": "Cruz07",
         "bibcode": "2007AJ....133..439C",
         "doi": "10.1086/510132",
         "description": "Meeting the Cool Neighbors. IX. The Luminosity Function of M7-L8 Ultracool Dwarfs in the Field"
     },
     {
-        "name": "Cruz09",
+        "publication": "Cruz09",
         "bibcode": "2009AJ....137.3345C",
         "doi": "10.1088/0004-6256/137/2/3345",
         "description": "Young L Dwarfs Identified in the Field: A Preliminary Low-Gravity, Optical Spectral Sequence from L0 to L5"
     },
     {
-        "name": "Curr11",
+        "publication": "Curr11",
         "bibcode": "2011ApJ...736L..33C",
         "doi": "10.1088/2041-8205/736/2/L33",
         "description": "A 5 {$\\mu$}m Image of {$\\beta$} Pictoris b at a Sub-Jupiter Projected Separation: Evidence for a Misalignment Between the Planet and the Inner, Warped Disk"
     },
     {
-        "name": "Cush05",
+        "publication": "Cush05",
         "bibcode": "2005ApJ...623.1115C",
         "doi": "10.1086/428040",
         "description": "An Infrared Spectroscopic Sequence of M, L, and T Dwarfs"
     },
     {
-        "name": "Cush09",
+        "publication": "Cush09",
         "bibcode": "2009ApJ...696..986C",
         "doi": "10.1088/0004-637X/696/1/986",
         "description": "2MASS J06164006-6407194: The First Outer Halo L Subdwarf"
     },
     {
-        "name": "Cush11",
+        "publication": "Cush11",
         "bibcode": "2011ApJ...743...50C",
         "doi": "10.1088/0004-637X/743/1/50",
         "description": "The Discovery of Y Dwarfs using Data from the Wide-field Infrared Survey Explorer (WISE)"
     },
     {
-        "name": "Dahn02",
+        "publication": "Dahn02",
         "bibcode": "2002AJ....124.1170D",
         "doi": "10.1086/341646",
         "description": "Astrometry and Photometry for Cool Dwarfs and Brown Dwarfs"
     },
     {
-        "name": "Dahn08",
+        "publication": "Dahn08",
         "bibcode": "2008ApJ...686..548D",
         "doi": "10.1086/591050",
         "description": "Trigonometric Parallaxes for Two Late-Type Subdwarfs: LSR 1425+71 (sdM8.0) and the Binary LSR 1610-00 (sd?M6pec)"
     },
     {
-        "name": "Deac05",
+        "publication": "Deac05",
         "bibcode": "2005AJ....129..409D",
         "doi": "10.1086/426330",
         "description": "The Solar Neighborhood. XI. The Trigonometric Parallax of SCR 1845-6357"
     },
     {
-        "name": "Deac11b",
+        "publication": "Deac11b",
         "bibcode": "2011arXiv1109.6319D",
         "doi": "10.1088/0004-637X/755/2/94",
         "description": "HIP 38939B: A New Benchmark T Dwarf in the Galactic Plane Discovered with Pan-STARRS1"
     },
     {
-        "name": "Delo08a",
+        "publication": "Delo08a",
         "bibcode": "2008A&A...482..961D",
         "doi": "10.1051/0004-6361:20079317",
         "description": "CFBDS J005910.90-011401.3: reaching the T-Y brown dwarf transition?"
     },
     {
-        "name": "Delo10",
+        "publication": "Delo10",
         "bibcode": "2010A&A...518A..39D",
         "doi": "10.1051/0004-6361/201014277",
         "description": "Extending the Canada-France brown dwarfs survey to the near-infrared: first ultracool brown dwarfs from CFBDSIR"
     },
     {
-        "name": "Duco08",
+        "publication": "Duco08",
         "bibcode": "2008A&A...477L...1D",
         "doi": "10.1051/0004-6361:20078886",
         "description": "An accurate distance to 2M1207Ab"
     },
     {
-        "name": "Dupu09c",
+        "publication": "Dupu09c",
         "bibcode": "2009ApJ...706..328D",
         "doi": "10.1088/0004-637X/706/1/328",
         "description": "Dynamical Mass of the M8+M8 Binary 2MASS J22062280 - 2047058AB"
     },
     {
-        "name": "Dupu09a",
+        "publication": "Dupu09a",
         "bibcode": "2009ApJ...692..729D",
         "doi": "10.1088/0004-637X/692/1/729",
         "description": "Dynamical Mass of the Substellar Benchmark Binary HD 130948BC"
     },
     {
-        "name": "Dupu09b",
+        "publication": "Dupu09b",
         "bibcode": "2009ApJ...699..168D",
         "doi": "10.1088/0004-637X/699/1/168",
         "description": "Keck Laser Guide Star Adaptive Optics Monitoring of the M8+L7 Binary LHS 2397aAB: First Dynamical Mass Benchmark at the L/T Transition"
     },
     {
-        "name": "Dupu10",
+        "publication": "Dupu10",
         "bibcode": "2010ApJ...721.1725D",
         "doi": "10.1088/0004-637X/721/2/1725",
         "description": "Studying the Physical Diversity of Late-M Dwarfs with Dynamical Masses"
     },
     {
-        "name": "Torr06",
+        "publication": "Torr06",
         "bibcode": "2006A&A...460..695T",
         "doi": "10.1051/0004-6361:20065602",
         "description": "Search for associations containing young stars (SACY). I. Sample and searching method"
     },
     {
-        "name": "Espo12",
+        "publication": "Espo12",
         "bibcode": "2012arXiv1203.2735E",
         "doi": "10.1051/0004-6361/201219212",
         "description": "LBT observations of the HR 8799 planetary system. First detection of HR 8799e in H band"
     },
     {
-        "name": "Fan_00",
+        "publication": "Fan_00",
         "bibcode": "2000AJ....119..928F",
         "doi": "10.1086/301224",
         "description": "L Dwarfs Found in Sloan Digital Sky Survey Commissioning Imaging Data"
     },
     {
-        "name": "Fahe10",
+        "publication": "Fahe10",
         "bibcode": "2010AJ....139..176F",
         "doi": "10.1088/0004-6256/139/1/176",
         "description": "The Brown Dwarf Kinematics Project. II. Details on Nine Wide Common Proper Motion Very Low Mass Companions to Nearby Stars"
     },
     {
-        "name": "Fahe11",
+        "publication": "Fahe11",
         "bibcode": "2011AJ....141...71F",
         "doi": "10.1088/0004-6256/141/3/71",
         "description": "Identification of a Wide, Low-Mass Multiple System Containing the Brown Dwarf 2MASS J0850359+105716"
     },
     {
-        "name": "Fahe12",
+        "publication": "Fahe12",
         "bibcode": "2012ApJ...752...56F",
         "doi": "10.1088/0004-637X/752/1/56",
         "description": "The Brown Dwarf Kinematics Project (BDKP). III. Parallaxes for 70 Ultracool Dwarfs"
     },
     {
-        "name": "Forr88",
+        "publication": "Forr88",
         "bibcode": "1988ApJ...330L.119F",
         "doi": "10.1086/185218",
         "description": "A possible brown dwarf companion to Gliese 569"
     },
     {
-        "name": "Forv04",
+        "publication": "Forv04",
         "bibcode": "2004A&A...427L...1F",
         "doi": "10.1051/0004-6361:200400069",
         "description": "An L0 dwarf companion in the brown dwarf desert, at 30 AU"
     },
     {
-        "name": "Forv05",
+        "publication": "Forv05",
         "bibcode": "2005A&A...435L...5F",
         "doi": "10.1051/0004-6361:200500101",
         "description": "LP 349-25: A new tight M8V binary"
     },
     {
-        "name": "Free03",
+        "publication": "Free03",
         "bibcode": "2003ApJ...584..453F",
         "doi": "10.1086/345533",
         "description": "Discovery of a Tight Brown Dwarf Companion to theLow-Mass Star LHS 2397a"
     },
     {
-        "name": "Gali11",
+        "publication": "Gali11",
         "bibcode": "2011ApJ...739L..41G",
         "doi": "10.1088/2041-8205/739/2/L41",
         "description": "M-band Imaging of the HR 8799 Planetary System Using an Innovative LOCI-based Background Subtraction Technique"
     },
     {
-        "name": "Gate09",
+        "publication": "Gate09",
         "bibcode": "2009AJ....137..402G",
         "doi": "10.1088/0004-6256/137/1/402",
         "description": "Allegheny Observatory Parallaxes for Late M Dwarfs and White Dwarfs"
     },
     {
-        "name": "Geba01",
+        "publication": "Geba01",
         "bibcode": "2001ApJ...556..373G",
         "doi": "10.1086/321575",
         "description": "Infrared Observations and Modeling of One of the Coolest T Dwarfs: Gliese 570D"
     },
     {
-        "name": "Geba02",
+        "publication": "Geba02",
         "bibcode": "2002ApJ...564..466G",
         "doi": "10.1086/324078",
         "description": "Toward Spectral Classification of L and T Dwarfs: Infrared and Optical Spectroscopy and Analysis"
     },
     {
-        "name": "Geli06",
+        "publication": "Geli06",
         "bibcode": "2006PASP..118..611G",
         "doi": "10.1086/502985",
         "description": "Evidence of Orbital Motion in the Binary Brown Dwarf Kelu-1AB"
     },
     {
-        "name": "Geli11",
+        "publication": "Geli11",
         "bibcode": "2011AJ....142...57G",
         "doi": "10.1088/0004-6256/142/2/57",
         "description": "WISE Brown Dwarf Binaries: The Discovery of a T5+T5 and a T8.5+T9 System"
     },
     {
-        "name": "Geye88",
+        "publication": "Geye88",
         "bibcode": "1988AJ.....95.1841G",
         "doi": "10.1086/114781",
         "description": "Parallax, orbit, and mass of the visual binary L726-8"
     },
     {
-        "name": "GiRe00",
+        "publication": "GiRe00",
         "bibcode": "2000PASP..112..610G",
         "doi": "10.1086/316558",
         "description": "Hubble Space Telescope Observations of M Subdwarfs"
     },
     {
-        "name": "Gizi97",
+        "publication": "Gizi97",
         "bibcode": "1997AJ....113..806G",
         "doi": "10.1086/118302",
         "description": "M-Subdwarfs: Spectroscopic Classification and the Metallicity Scale"
     },
     {
-        "name": "Gizi00",
+        "publication": "Gizi00",
         "bibcode": "2000AJ....120.1085G",
         "doi": "10.1086/301456",
         "description": "New Neighbors from 2MASS: Activity and Kinematics at the Bottom of the Main Sequence"
     },
     {
-        "name": "Gizi01",
+        "publication": "Gizi01",
         "bibcode": "2001AJ....121.2185G",
         "doi": "10.1086/319937",
         "description": "A 2MASS L Dwarf Companion to the Nearby K Dwarf GJ 1048"
     },
     {
-        "name": "Gizi02a",
+        "publication": "Gizi02a",
         "bibcode": "2002AJ....123.3356G",
         "doi": "10.1086/340465",
         "description": "The Palomar/MSU Nearby Star Spectroscopic Survey. III. Chromospheric Activity, M Dwarf Ages, and the Local Star Formation History"
     },
     {
-        "name": "Gizi02b",
+        "publication": "Gizi02b",
         "bibcode": "2002ApJ...575..484G",
         "doi": "10.1086/341259",
         "description": "Brown Dwarfs and the TW Hydrae Association"
     },
     {
-        "name": "Gizi03",
+        "publication": "Gizi03",
         "bibcode": "2003AJ....125.3302G",
         "doi": "10.1086/374991",
         "description": "Hubble Space Telescope Observations of Binary Very Low Mass Stars and Brown Dwarfs"
     },
     {
-        "name": "Gizi07",
+        "publication": "Gizi07",
         "bibcode": "2007ApJ...669L..45G",
         "doi": "10.1086/523271",
         "description": "The Trigonometric Parallax of the Brown Dwarf Planetary System 2MASSW J1207334-393254"
     },
     {
-        "name": "Gold10",
+        "publication": "Gold10",
         "bibcode": "2010MNRAS.405.1140G",
         "doi": "10.1111/j.1365-2966.2010.16524.x",
         "description": "A new benchmark T8-9 brown dwarf and a couple of new mid-T dwarfs from the UKIDSS DR5+ LAS"
     },
     {
-        "name": "Goli98a",
+        "publication": "Goli98a",
         "bibcode": "1998AJ....115.2579G",
         "doi": "10.1086/300370",
         "description": "Wide Field Planetary Camera 2 Observations of the Brown Dwarf Gliese 229B: Optical Colors and Orbital Motion"
     },
     {
-        "name": "Goli98b",
+        "publication": "Goli98b",
         "bibcode": "1998AJ....116..440G",
         "doi": "10.1086/300437",
         "description": "Wide Field Planetary Camera 2 Observations of Proxima Centauri: No Evidence of the Possible Substellar Companion"
     },
     {
-        "name": "Goli04a",
+        "publication": "Goli04a",
         "bibcode": "2004AJ....127.3516G",
         "doi": "10.1086/420709",
         "description": "L\u2032 and M\u2032 Photometry of Ultracool Dwarfs"
     },
     {
-        "name": "Goli04b",
+        "publication": "Goli04b",
         "bibcode": "2004AJ....128.1733G",
         "doi": "10.1086/423911",
         "description": "The Solar Neighborhood. IX. Hubble Space Telescope Detections of Companions to Five M and L Dwarfs within 10 Parsecs of the Sun"
     },
     {
-        "name": "Goto02",
+        "publication": "Goto02",
         "bibcode": "2002ApJ...567L..59G",
         "doi": "10.1086/339800",
         "description": "Near-Infrared Adaptive Optics Spectroscopy of Binary Brown Dwarfs HD 130948B and HD 130948C"
     },
     {
-        "name": "Grei07",
+        "publication": "Grei07",
         "bibcode": "2007AJ....133.1321G",
         "doi": "10.1086/510901",
         "description": "Hubble Space Telescope NICMOS Observations of NGC 1333: The Ratio of Stars to Substellar Objects"
     },
     {
-        "name": "Guen01",
+        "publication": "Guen01",
         "bibcode": "2001A&A...365..514G",
         "doi": "10.1051/0004-6361:20000051",
         "description": "Infrared spectrum and proper motion of the brown dwarf companion of HR 7329 in Tucanae"
     },
     {
-        "name": "Harr80",
+        "publication": "Harr80",
         "bibcode": "1980AJ.....85..454H",
         "doi": "10.1086/112696",
         "description": "Summary of U.S. Naval Observatory parallaxes"
     },
     {
-        "name": "Harr93",
+        "publication": "Harr93",
         "bibcode": "1993AJ....105.1571H",
         "doi": "10.1086/116537",
         "description": "U.S. Naval Observatory photographic parallaxes - List IX"
     },
     {
-        "name": "Hawl02",
+        "publication": "Hawl02",
         "bibcode": "2002AJ....123.3409H",
         "doi": "10.1086/340697",
         "description": "Characterization of M, L, and T Dwarfs in the Sloan Digital Sky Survey"
     },
     {
-        "name": "Henr90",
+        "publication": "Henr90",
         "bibcode": "1990ApJ...354L..29H",
         "doi": "10.1086/185715",
         "description": "The Companion to Gliese 569"
     },
     {
-        "name": "Henr93",
+        "publication": "Henr93",
         "bibcode": "1993AJ....106..773H",
         "doi": "10.1086/116685",
         "description": "The mass-luminosity relation for stars of mass 1.0 to 0.08 solar mass"
     },
     {
-        "name": "Henr02",
+        "publication": "Henr02",
         "bibcode": "2002AJ....123.2002H",
         "doi": "10.1086/339315",
         "description": "The Solar Neighborhood. VI. New Southern Nearby Stars Identified by Optical Spectroscopy"
     },
     {
-        "name": "Henr04",
+        "publication": "Henr04",
         "bibcode": "2004AJ....128.2460H",
         "doi": "10.1086/425052",
         "description": "The Solar Neighborhood. X. New Nearby Stars in the Southern Sky and Accurate Photometric Distance Estimates for Red Dwarfs"
     },
     {
-        "name": "Henr06",
+        "publication": "Henr06",
         "bibcode": "2006AJ....132.2360H",
         "doi": "10.1086/508233",
         "description": "The Solar Neighborhood. XVII. Parallax Results from the CTIOPI 0.9 m Program: 20 New Members of the RECONS 10 Parsec Sample"
     },
     {
-        "name": "Hewe06",
+        "publication": "Hewe06",
         "bibcode": "2006MNRAS.367..454H",
         "doi": "10.1111/j.1365-2966.2005.09969.x",
         "description": "The UKIRT Infrared Deep Sky Survey ZY JHK photometric system: passbands and synthetic colours"
     },
     {
-        "name": "Huel10",
+        "publication": "Huel10",
         "bibcode": "2010A&A...521L..54H",
         "doi": "10.1051/0004-6361/201015708",
         "description": "A brown dwarf companion to the intermediate-mass star HR 6037"
     },
     {
-        "name": "Irel08",
+        "publication": "Irel08",
         "bibcode": "2008ApJ...678..463I",
         "doi": "10.1086/529578",
         "description": "Dynamical Mass of GJ 802B: A Brown Dwarf in a Triple System"
     },
     {
-        "name": "Jans11",
+        "publication": "Jans11",
         "bibcode": "2011ApJ...728...85J",
         "doi": "10.1088/0004-637X/728/2/85",
         "description": "Near-infrared Multi-band Photometry of the Substellar Companion GJ 758 B"
     },
     {
-        "name": "Jaya03",
+        "publication": "Jaya03",
         "bibcode": "2003AJ....126.1515J",
         "doi": "10.1086/377144",
         "description": "A Disk Census for Young Brown Dwarfs"
     },
     {
-        "name": "Jone96",
+        "publication": "Jone96",
         "bibcode": "1996MNRAS.280...77J",
         "doi": "10.1093/mnras/280.1.77",
         "description": "Spectral analysis of M dwarfs"
     },
     {
-        "name": "Kasp07",
+        "publication": "Kasp07",
         "bibcode": "2007A&A...471..655K",
         "doi": "10.1051/0004-6361:20077881",
         "description": "The very nearby M/T dwarf binary SCR 1845-6357"
     },
     {
-        "name": "Kend04",
+        "publication": "Kend04",
         "bibcode": "2004A&A...416L..17K",
         "doi": "10.1051/0004-6361:20040046",
         "description": "Discovery of very nearby ultracool dwarfs from DENIS"
     },
     {
-        "name": "Kend07",
+        "publication": "Kend07",
         "bibcode": "2007MNRAS.374..445K",
         "doi": "10.1111/j.1365-2966.2006.11026.x",
         "description": "New nearby, bright southern ultracool dwarfs"
     },
     {
-        "name": "Kenw01",
+        "publication": "Kenw01",
         "bibcode": "2001ApJ...554L..67K",
         "doi": "10.1086/320934",
         "description": "Gliese 569B: A Young Multiple Brown Dwarf System?"
     },
     {
-        "name": "King10",
+        "publication": "King10",
         "bibcode": "2010A&A...510A..99K",
         "doi": "10.1051/0004-6361/200912981",
         "description": "{$\\epsilon$} Indi Ba, Bb: a detailed study of the nearest known brown dwarfs"
     },
     {
-        "name": "Kirk91",
+        "publication": "Kirk91",
         "bibcode": "1991ApJS...77..417K",
         "doi": "10.1086/191611",
         "description": "A standard stellar spectral sequence in the red/near-infrared - Classes K5 to M9"
     },
     {
-        "name": "Kirk94",
+        "publication": "Kirk94",
         "bibcode": "1994ApJS...94..749K",
         "doi": "10.1086/192089",
         "description": "The luminosity function at the end of the main sequence: Results of a deep, large-area, CCD survey for cool dwarfs"
     },
     {
-        "name": "Kirk95",
+        "publication": "Kirk95",
         "bibcode": "1995AJ....109..797K",
         "doi": "10.1086/117323",
         "description": "The solar neighborhood. 2: The first list of dwarfs with spectral types of M7 and cooler"
     },
     {
-        "name": "Kirk97a",
+        "publication": "Kirk97a",
         "bibcode": "1997ApJ...476..311K",
         "doi": "10.1086/303613",
         "description": "The Coolest Isolated M Dwarf and Other 2MASS Discoveries"
     },
     {
-        "name": "Kirk99a",
+        "publication": "Kirk99a",
         "bibcode": "1999ApJ...519..802K",
         "doi": "10.1086/307414",
         "description": "Dwarfs Cooler than ``M'': The Definition of Spectral Type L Using Discoveries from the 2 Micron All-Sky Survey (2MASS)"
     },
     {
-        "name": "Kirk00",
+        "publication": "Kirk00",
         "bibcode": "2000AJ....120..447K",
         "doi": "10.1086/301427",
         "description": "67 Additional L Dwarfs Discovered by the Two Micron All Sky Survey"
     },
     {
-        "name": "Kirk01a",
+        "publication": "Kirk01a",
         "bibcode": "2001AJ....121.3235K",
         "doi": "10.1086/321085",
         "description": "Brown Dwarf Companions to G-Type Stars. I. Gliese 417B and Gliese 584C"
     },
     {
-        "name": "Kirk01b",
+        "publication": "Kirk01b",
         "bibcode": "2001PASP..113..814K",
         "doi": "10.1086/322142",
         "description": "Three Newly Discovered M-Dwarf Companions of Solar Neighborhood Stars"
     },
     {
-        "name": "Kirk08",
+        "publication": "Kirk08",
         "bibcode": "2008ApJ...689.1295K",
         "doi": "10.1086/592768",
         "description": "A Sample of Very Young Field L Dwarfs and Implications for the Brown Dwarf ``Lithium Test'' at Early Ages"
     },
     {
-        "name": "Kirk11",
+        "publication": "Kirk11",
         "bibcode": "2011ApJS..197...19K",
         "doi": "10.1088/0067-0049/197/2/19",
         "description": "The First Hundred Brown Dwarfs Discovered by the Wide-field Infrared Survey Explorer (WISE)"
     },
     {
-        "name": "Knap04",
+        "publication": "Knap04",
         "bibcode": "2004AJ....127.3553K",
         "doi": "10.1086/420707",
         "description": "Near-Infrared Photometry and Spectroscopy of L and T Dwarfs: The Effects of Temperature, Clouds, and Gravity"
     },
     {
-        "name": "Koer99",
+        "publication": "Koer99",
         "bibcode": "1999ApJ...526L..25K",
         "doi": "10.1086/312367",
         "description": "Keck Imaging of Binary L Dwarfs"
     },
     {
-        "name": "Kono10",
+        "publication": "Kono10",
         "bibcode": "2010ApJ...711.1087K",
         "doi": "10.1088/0004-637X/711/2/1087",
         "description": "High-precision Dynamical Masses of Very Low Mass Binaries"
     },
     {
-        "name": "Lagr10",
+        "publication": "Lagr10",
         "bibcode": "2010Sci...329...57L",
         "doi": "10.1126/science.1187187",
         "description": "A Giant Planet Imaged in the Disk of the Young Star {$\\beta$} Pictoris"
     },
     {
-        "name": "Lane01",
+        "publication": "Lane01",
         "bibcode": "2001ApJ...560..390L",
         "doi": "10.1086/322506",
         "description": "The Orbit of the Brown Dwarf Binary Gliese 569B"
     },
     {
-        "name": "Law_06b",
+        "publication": "Law_06b",
         "bibcode": "2006A&A...446..739L",
         "doi": "10.1051/0004-6361:20053695",
         "description": "Lucky imaging: high angular resolution imaging in the visible from the ground"
     },
     {
-        "name": "Legg92",
+        "publication": "Legg92",
         "bibcode": "1992ApJS...82..351L",
         "doi": "10.1086/191720",
         "description": "Infrared colors of low-mass stars"
     },
     {
-        "name": "Legg98",
+        "publication": "Legg98",
         "bibcode": "1998ApJ...509..836L",
         "doi": "10.1086/306517",
         "description": "Infrared Colors at the Stellar/Substellar Boundary"
     },
     {
-        "name": "Legg00",
+        "publication": "Legg00",
         "bibcode": "2000ApJ...536L..35L",
         "doi": "10.1086/312728",
         "description": "The Missing Link: Early Methane (``T'') Dwarfs in the Sloan Digital Sky Survey"
     },
     {
-        "name": "Legg01",
+        "publication": "Legg01",
         "bibcode": "2001ApJ...548..908L",
         "doi": "10.1086/319020",
         "description": "Infrared Spectra and Spectral Energy Distributions of Late M and L Dwarfs"
     },
     {
-        "name": "Legg02a",
+        "publication": "Legg02a",
         "bibcode": "2002ApJ...564..452L",
         "doi": "10.1086/324037",
         "description": "Infrared Photometry of Late-M, L, and T Dwarfs"
     },
     {
-        "name": "Legg02b",
+        "publication": "Legg02b",
         "bibcode": "2002MNRAS.332...78L",
         "doi": "10.1046/j.1365-8711.2002.05273.x",
         "description": "Atmospheric analysis of the M/L and M/T dwarf binary systems LHS 102 and Gliese 229"
     },
     {
-        "name": "Legg07b",
+        "publication": "Legg07b",
         "bibcode": "2007ApJ...655.1079L",
         "doi": "10.1086/510014",
         "description": "3.6-7.9 \u03bcm Photometry of L and T Dwarfs and the Prevalence of Vertical Mixing in their Atmospheres"
     },
     {
-        "name": "Legg08",
+        "publication": "Legg08",
         "bibcode": "2008ApJ...682.1256L",
         "doi": "10.1086/589146",
         "description": "HN Peg B: A Test of Models of the L to T Dwarf Transition"
     },
     {
-        "name": "Legg09",
+        "publication": "Legg09",
         "bibcode": "2009ApJ...695.1517L",
         "doi": "10.1088/0004-637X/695/2/1517",
         "description": "The Physical Properties of Four \\~{}600 K T Dwarfs"
     },
     {
-        "name": "Legg10",
+        "publication": "Legg10",
         "bibcode": "2010ApJ...710.1627L",
         "doi": "10.1088/0004-637X/710/2/1627",
         "description": "Mid-Infrared Photometry of Cold Brown Dwarfs: Diversity in Age, Mass, and Metallicity"
     },
     {
-        "name": "Legg14",
+        "publication": "Legg14",
         "bibcode": "2014ApJ...780...62L",
         "doi": "10.1088/0004-637X/780/1/62",
         "description": "Resolved Spectroscopy of the T8.5 and Y0-0.5 Binary WISEPC J121756.91+162640.2AB"
     },
     {
-        "name": "Lein94",
+        "publication": "Lein94",
         "bibcode": "1994A&A...291L..47L",
         "doi": null,
         "description": "Two faint companions to the nearby low-mass star LHS 1070"
     },
     {
-        "name": "Lein97",
+        "publication": "Lein97",
         "bibcode": "1997A&A...325..159L",
         "doi": null,
         "description": "A search for companions to nearby southern M dwarfs with near-infrared speckle interferometry."
     },
     {
-        "name": "Lein00",
+        "publication": "Lein00",
         "bibcode": "2000A&A...353..691L",
         "doi": null,
         "description": "The multiple system LHS 1070: a case study for the onset of dust formation in the atmospheres of very low mass stars"
     },
     {
-        "name": "Lein01",
+        "publication": "Lein01",
         "bibcode": "2001A&A...367..183L",
         "doi": "10.1051/0004-6361:20000408",
         "description": "Dynamical mass determination for the very low mass stars LHS 1070 B and C"
     },
     {
-        "name": "Lepi03a",
+        "publication": "Lepi03a",
         "bibcode": "2003AJ....125.1598L",
         "doi": "10.1086/345972",
         "description": "Spectroscopy of New High Proper Motion Stars in the Northern Sky. I. New Nearby Stars, New High-Velocity Stars, and an Enhanced Classification Scheme for M Dwarfs"
     },
     {
-        "name": "Lepi03b",
+        "publication": "Lepi03b",
         "bibcode": "2003ApJ...585L..69L",
         "doi": "10.1086/374210",
         "description": "Discovery of an Ultracool Subdwarf: LSR 1425+7102, the First Star with Spectral Type sdM8.0"
     },
     {
-        "name": "Lepi03c",
+        "publication": "Lepi03c",
         "bibcode": "2003ApJ...591L..49L",
         "doi": "10.1086/377069",
         "description": "LSR 1610-0040: The First Early-Type L Subdwarf"
     },
     {
-        "name": "Lepi05",
+        "publication": "Lepi05",
         "bibcode": "2005AJ....129.1483L",
         "doi": "10.1086/427854",
         "description": "A Catalog of Northern Stars with Annual Proper Motions Larger than 0.15'' (LSPM-NORTH Catalog)"
     },
     {
-        "name": "Lepi09",
+        "publication": "Lepi09",
         "bibcode": "2009AJ....137.4109L",
         "doi": "10.1088/0004-6256/137/5/4109",
         "description": "New Neighbors: Parallaxes of 18 Nearby Stars Selected from the LSPM-North Catalog"
     },
     {
-        "name": "Liu_02",
+        "publication": "Liu_02",
         "bibcode": "2001astro.ph.12407L",
         "doi": "10.1086/339845",
         "description": "Crossing the Brown Dwarf Desert Using Adaptive Optics: A Very Close L Dwarf Companion to the Nearby Solar Analog HR 7672"
     },
     {
-        "name": "Liu_05",
+        "publication": "Liu_05",
         "bibcode": "2005ApJ...634..616L",
         "doi": "10.1086/496915",
         "description": "Kelu-1 Is a Binary L Dwarf: First Brown Dwarf Science from Laser Guide Star Adaptive Optics"
     },
     {
-        "name": "Liu_06",
+        "publication": "Liu_06",
         "bibcode": "2006ApJ...647.1393L",
         "doi": "10.1086/505561",
         "description": "SDSS J1534+1615AB: A Novel T Dwarf Binary Found with Keck Laser Guide Star Adaptive Optics and the Potential Role of Binarity in the L/T Transition"
     },
     {
-        "name": "Liu_07",
+        "publication": "Liu_07",
         "bibcode": "2007ApJ...660.1507L",
         "doi": "10.1086/512662",
         "description": "The Late-T Dwarf Companion to the Exoplanet Host Star HD 3651: A New Benchmark for Gravity and Metallicity Effects in Ultracool Spectra"
     },
     {
-        "name": "Liu_08",
+        "publication": "Liu_08",
         "bibcode": "2008ApJ...689..436L",
         "doi": "10.1086/591837",
         "description": "Keck Laser Guide Star Adaptive Optics Monitoring of 2MASS J15344984-2952274AB: First Dynamical Mass Determination of a Binary T Dwarf"
     },
     {
-        "name": "Liu_10",
+        "publication": "Liu_10",
         "bibcode": "2010ApJ...722..311L",
         "doi": "10.1088/0004-637X/722/1/311",
         "description": "Discovery of a Highly Unequal-mass Binary T Dwarf with Keck Laser Guide Star Adaptive Optics: A Coevality Test of Substellar Theoretical Models and Effective Temperatures"
     },
     {
-        "name": "Liu_11a",
+        "publication": "Liu_11a",
         "bibcode": "2011ApJ...740L..32L",
         "doi": "10.1088/2041-8205/740/2/L32",
         "description": "A Search for High Proper Motion T Dwarfs with PAN-STARRS1 + 2MASS + WISE"
     },
     {
-        "name": "Liu_11b",
+        "publication": "Liu_11b",
         "bibcode": "2011ApJ...740..108L",
         "doi": "10.1088/0004-637X/740/2/108",
         "description": "CFBDSIR J1458+1013B: A Very Cold ($\\gt$T10) Brown Dwarf in a Binary System"
     },
     {
-        "name": "Lodi05",
+        "publication": "Lodi05",
         "bibcode": "2005A&A...440.1061L",
         "doi": "10.1051/0004-6361:20042456",
         "description": "Spectroscopic classification of red high proper motion objects in the Southern Sky"
     },
     {
-        "name": "Lodi07a",
+        "publication": "Lodi07a",
         "bibcode": "2007MNRAS.379.1423L",
         "doi": "10.1111/j.1365-2966.2007.12023.x",
         "description": "Eight new T4.5-T7.5 dwarfs discovered in the UKIDSS Large Area Survey Data Release 1"
     },
     {
-        "name": "Loop07a",
+        "publication": "Loop07a",
         "bibcode": "2007AJ....134.1162L",
         "doi": "10.1086/520645",
         "description": "Discovery of 11 New T Dwarfs in the Two Micron All Sky Survey, Including a Possible L/T Transition Binary"
     },
     {
-        "name": "Loop08a",
+        "publication": "Loop08a",
         "bibcode": "2008ApJ...685.1183L",
         "doi": "10.1086/590382",
         "description": "Discovery of a T Dwarf Binary with the Largest Known J-Band Flux Reversal"
     },
     {
-        "name": "Loop08b",
+        "publication": "Loop08b",
         "bibcode": "2008ApJ...686..528L",
         "doi": "10.1086/591025",
         "description": "Discovery of Two Nearby Peculiar L Dwarfs from the 2MASS Proper-Motion Survey: Young or Metal-Rich?"
     },
     {
-        "name": "Lout11",
+        "publication": "Lout11",
         "bibcode": "2011ApJ...739...81L",
         "doi": "10.1088/0004-637X/739/2/81",
         "description": "Discovery of a Companion at the L/T Transition with the Wide-field Infrared Survey Explorer"
     },
     {
-        "name": "Lowr00",
+        "publication": "Lowr00",
         "bibcode": "2000ApJ...541..390L",
         "doi": "10.1086/309437",
         "description": "A Candidate Substellar Companion to HR 7329"
     },
     {
-        "name": "Lowr05",
+        "publication": "Lowr05",
         "bibcode": "2005AJ....130.1845L",
         "doi": "10.1086/432839",
         "description": "An Infrared Coronagraphic Survey for Substellar Companions"
     },
     {
-        "name": "Luca10",
+        "publication": "Luca10",
         "bibcode": "2010MNRAS.408L..56L",
         "doi": "10.1111/j.1745-3933.2010.00927.x",
         "description": "The discovery of a very cool, very nearby brown dwarf in the Galactic plane"
     },
     {
-        "name": "Luhm07a",
+        "publication": "Luhm07a",
         "bibcode": "2007ApJ...654..570L",
         "doi": "10.1086/509073",
         "description": "Discovery of Two T Dwarf Companions with the Spitzer Space Telescope"
     },
     {
-        "name": "Luhm11",
+        "publication": "Luhm11",
         "bibcode": "2011ApJ...730L...9L",
         "doi": "10.1088/2041-8205/730/1/L9",
         "description": "Discovery of a Candidate for the Coolest Known Brown Dwarf"
     },
     {
-        "name": "Luhm12",
+        "publication": "Luhm12",
         "bibcode": "2012ApJ...744..135L",
         "doi": "10.1088/0004-637X/744/2/135",
         "description": "Confirmation of One of the Coldest Known Brown Dwarfs"
     },
     {
-        "name": "Maro08",
+        "publication": "Maro08",
         "bibcode": "2008Sci...322.1348M",
         "doi": "10.1126/science.1166585",
         "description": "Direct Imaging of Multiple Planets Orbiting the Star HR 8799"
     },
     {
-        "name": "Maro10a",
+        "publication": "Maro10a",
         "bibcode": "2010A&A...524A..38M",
         "doi": "10.1051/0004-6361/201015394",
         "description": "Parallaxes and physical properties of 11 mid-to-late T dwarfs"
     },
     {
-        "name": "Maro10b",
+        "publication": "Maro10b",
         "bibcode": "2010Natur.468.1080M",
         "doi": "10.1038/nature09684",
         "description": "Images of a fourth planet orbiting HR 8799"
     },
     {
-        "name": "Mart99a",
+        "publication": "Mart99a",
         "bibcode": "1999Sci...283.1718M",
         "doi": "10.1126/science.283.5408.1718",
         "description": "A Search for Companions to Nearby Brown Dwarfs: The Binary DENIS-P J1228.2-1547"
     },
     {
-        "name": "Mart99.107",
+        "publication": "Mart99.107",
         "bibcode": "1999AJ....118.2466M",
         "doi": "10.1086/301107",
         "description": "Spectroscopic Classification of Late-M and L Field Dwarfs"
     },
     {
-        "name": "Mart00",
+        "publication": "Mart00",
         "bibcode": "2000ApJ...529L..37M",
         "doi": "10.1086/312450",
         "description": "The Discovery of a Companion to the Very Cool Dwarf Gliese 569B with the Keck Adaptive Optics Facility"
     },
     {
-        "name": "Mart06",
+        "publication": "Mart06",
         "bibcode": "2006A&A...456..253M",
         "doi": "10.1051/0004-6361:20054186",
         "description": "Resolved Hubble space spectroscopy of ultracool binary systems"
     },
     {
-        "name": "McLe03",
+        "publication": "McLe03",
         "bibcode": "2003ApJ...596..561M",
         "doi": "10.1086/377636",
         "description": "The NIRSPEC Brown Dwarf Spectroscopic Survey. I. Low-Resolution Near-Infrared Spectra"
     },
     {
-        "name": "MeHi04",
+        "publication": "MeHi04",
         "bibcode": "2004ApJ...617.1330M",
         "doi": "10.1086/425410",
         "description": "Initial Results from the Palomar Adaptive Optics Survey of Young Solar-Type Stars: A Brown Dwarf and Three Stellar Companions"
     },
     {
-        "name": "MeHi06",
+        "publication": "MeHi06",
         "bibcode": "2006ApJ...651.1166M",
         "doi": "10.1086/507836",
         "description": "HD 203030B: An Unusually Cool Young Substellar Companion near the L/T Transition"
     },
     {
-        "name": "Metc09",
+        "publication": "Metc09",
         "bibcode": "2009ApJ...705L.204M",
         "doi": "10.1088/0004-637X/705/2/L204",
         "description": "Pre-Discovery 2007 Image of the HR 8799 Planetary System"
     },
     {
-        "name": "Moha03",
+        "publication": "Moha03",
         "bibcode": "2003ApJ...593L.109M",
         "doi": "10.1086/378315",
         "description": "Magellan Echelle Spectroscopy of TW Hydrae Brown Dwarfs"
     },
     {
-        "name": "Moha07",
+        "publication": "Moha07",
         "bibcode": "2007ApJ...657.1064M",
         "doi": "10.1086/510877",
         "description": "The Planetary Mass Companion 2MASS 1207-3932B: Temperature, Mass, and Evidence for an Edge-on Disk"
     },
     {
-        "name": "Mone92",
+        "publication": "Mone92",
         "bibcode": "1992AJ....103..638M",
         "doi": "10.1086/116091",
         "description": "U.S. Naval Observatory CCD Parallaxes of Faint Stars. I. Program Description and First Results"
     },
     {
-        "name": "Mont06",
+        "publication": "Mont06",
         "bibcode": "2006A&A...460L..19M",
         "doi": "10.1051/0004-6361:20066120",
         "description": "Five new very low mass binaries"
     },
     {
-        "name": "Mugr07",
+        "publication": "Mugr07",
         "bibcode": "2007MNRAS.378.1328M",
         "doi": "10.1111/j.1365-2966.2007.11858.x",
         "description": "The multiplicity of planet host stars - new low-mass companions to planet host stars"
     },
     {
-        "name": "Murr11",
+        "publication": "Murr11",
         "bibcode": "2011MNRAS.414..575M",
         "doi": "10.1111/j.1365-2966.2011.18424.x",
         "description": "Blue not brown: UKIRT Infrared Deep Sky Survey T dwarfs with suppressed K-band flux"
     },
     {
-        "name": "Naka04",
+        "publication": "Naka04",
         "bibcode": "2004ApJ...607..499N",
         "doi": "10.1086/383299",
         "description": "Spectral Classification and Effective Temperatures of L and T Dwarfs Based on Near-Infrared Spectra"
     },
     {
-        "name": "Niel12",
+        "publication": "Niel12",
         "bibcode": "2012ApJ...750...53N",
         "doi": "10.1088/0004-637X/750/1/53",
         "description": "The Gemini NICI Planet-Finding Campaign: Discovery of a Multiple System Orbiting the Young A Star HD 1160"
     },
     {
-        "name": "Pati02",
+        "publication": "Pati02",
         "bibcode": "2002ApJ...581..654P",
         "doi": "10.1086/342982",
         "description": "Stellar Companions to Stars with Planets"
     },
     {
-        "name": "Pati10",
+        "publication": "Pati10",
         "bibcode": "2010A&A...517A..76P",
         "doi": "10.1051/0004-6361/201014173",
         "description": "The highest resolution near infrared spectrum of the imaged planetary mass companion 2M1207 b"
     },
     {
-        "name": "Patt06",
+        "publication": "Patt06",
         "bibcode": "2006ApJ...651..502P",
         "doi": "10.1086/507264",
         "description": "Spitzer IRAC Photometry of M, L, and T Dwarfs"
     },
     {
-        "name": "Phan06b",
+        "publication": "Phan06b",
         "bibcode": "2006MNRAS.366L..40P",
         "doi": "10.1111/j.1745-3933.2005.00128.x",
         "description": "Discovery of a nearby M9 dwarf"
     },
     {
-        "name": "Pott02",
+        "publication": "Pott02",
         "bibcode": "2002ApJ...567L.133P",
         "doi": "10.1086/339999",
         "description": "Hokupa'a-Gemini Discovery of Two Ultracool Companions to the Young Star HD 130948"
     },
     {
-        "name": "Pinf08",
+        "publication": "Pinf08",
         "bibcode": "2008MNRAS.390..304P",
         "doi": "10.1111/j.1365-2966.2008.13729.x",
         "description": "Fifteen new T dwarfs discovered in the UKIDSS Large Area Survey"
     },
     {
-        "name": "Pinf12",
+        "publication": "Pinf12",
         "bibcode": "2012MNRAS.422.1922P",
         "doi": "10.1111/j.1365-2966.2012.20549.x",
         "description": "Discovery of the benchmark metal-poor T8 dwarf BD +01{\\deg} 2920B"
     },
     {
-        "name": "Prav05",
+        "publication": "Prav05",
         "bibcode": "2005ApJ...630..528P",
         "doi": "10.1086/431967",
         "description": "Astrometric Discovery of GJ 802b: In the Brown Dwarf Oasis?"
     },
     {
-        "name": "Reid95",
+        "publication": "Reid95",
         "bibcode": "1995AJ....110.1838R",
         "doi": "10.1086/117655",
         "description": "The Palomar/MSU Nearby-Star Spectroscopic Survey. I. The Northern M Dwarfs -Bandstrengths and Kinematics"
     },
     {
-        "name": "Reid01",
+        "publication": "Reid01",
         "bibcode": "2001AJ....121..489R",
         "doi": "10.1086/318023",
         "description": "A Search for L Dwarf Binary Systems"
     },
     {
-        "name": "Reid02a",
+        "publication": "Reid02a",
         "bibcode": "2002AJ....123..466R",
         "doi": "10.1086/338083",
         "description": "5 Micron Photometry of Late-Type Dwarfs"
     },
     {
-        "name": "Reid02b",
+        "publication": "Reid02b",
         "bibcode": "2002AJ....123.2806R",
         "doi": "10.1086/339699",
         "description": "Meeting the Cool Neighbors. I. Nearby Stars in the NLTT Catalogue: Defining the Sample"
     },
     {
-        "name": "Reid02c",
+        "publication": "Reid02c",
         "bibcode": "2002AJ....124..519R",
         "doi": "10.1086/340805",
         "description": "High-Resolution Spectroscopy of Ultracool M Dwarfs"
     },
     {
-        "name": "Reid03c",
+        "publication": "Reid03c",
         "bibcode": "2003AJ....126.3007R",
         "doi": "10.1086/379173",
         "description": "Meeting the Cool Neighbors. VII. Spectroscopy of Faint Red NLTT Dwarfs"
     },
     {
-        "name": "Reid03a",
+        "publication": "Reid03a",
         "bibcode": "2003AJ....125..354R",
         "doi": "10.1086/344946",
         "description": "Meeting the Cool Neighbors. IV. 2MASS 1835+32, a Newly Discovered M8.5 Dwarf within 6 Parsecs of the Sun"
     },
     {
-        "name": "Reid04",
+        "publication": "Reid04",
         "bibcode": "2004AJ....128..463R",
         "doi": "10.1086/421374",
         "description": "Meeting the Cool Neighbors. VIII. A Preliminary 20 Parsec Census from the NLTT Catalogue"
     },
     {
-        "name": "Reid06a",
+        "publication": "Reid06a",
         "bibcode": "2006AJ....132..891R",
         "doi": "10.1086/505626",
         "description": "A Search for Binary Systems among the Nearest L Dwarfs"
     },
     {
-        "name": "Reid06b",
+        "publication": "Reid06b",
         "bibcode": "2006ApJ...639.1114R",
         "doi": "10.1086/499484",
         "description": "2MASS J22521073-1730134: A Resolved L/T Binary at 14 Parsecs"
     },
     {
-        "name": "Reid08a",
+        "publication": "Reid08a",
         "bibcode": "2008AJ....135..580R",
         "doi": "10.1088/0004-6256/135/2/580",
         "description": "L-Dwarf Binaries in the 20-Parsec Sample"
     },
     {
-        "name": "Reid08b",
+        "publication": "Reid08b",
         "bibcode": "2008AJ....136.1290R",
         "doi": "10.1088/0004-6256/136/3/1290",
         "description": "Meeting the Cool Neighbors. X. Ultracool Dwarfs from the 2MASS All-Sky Data Release"
     },
     {
-        "name": "Rein06",
+        "publication": "Rein06",
         "bibcode": "2006AJ....131.1806R",
         "doi": "10.1086/500298",
         "description": "The First High-Resolution Spectra of 1.3 L Subdwarfs"
     },
     {
-        "name": "ReWa06",
+        "publication": "ReWa06",
         "bibcode": "2006PASP..118..671R",
         "doi": "10.1086/503446",
         "description": "LP 261-75/2MASSW J09510549+3558021: A Young, Wide M4.5/L6 Binary"
     },
     {
-        "name": "Riaz06",
+        "publication": "Riaz06",
         "bibcode": "2006ApJ...639L..79R",
         "doi": "10.1086/502647",
         "description": "Spitzer Observations of Two TW Hydrae Association Brown Dwarfs"
     },
     {
-        "name": "Riaz08a",
+        "publication": "Riaz08a",
         "bibcode": "2008ApJ...672.1153R",
         "doi": "10.1086/523931",
         "description": "Hubble Space Telescope Search for M Subdwarf Binaries"
     },
     {
-        "name": "Rice10b",
+        "publication": "Rice10b",
         "bibcode": "2010ApJ...715L.165R",
         "doi": "10.1088/2041-8205/715/2/L165",
         "description": "The Lowest-mass Member of the beta Pictoris Moving Group"
     },
     {
-        "name": "Roes10",
+        "publication": "Roes10",
         "bibcode": "2010AJ....139.2440R",
         "doi": "10.1088/0004-6256/139/6/2440",
         "description": "The PPMXL Catalog of Positions and Proper Motions on the ICRS. Combining USNO-B1.0 and the Two Micron All Sky Survey (2MASS)"
     },
     {
-        "name": "Ruiz91",
+        "publication": "Ruiz91",
         "bibcode": "1991ApJ...367L..59R",
         "doi": "10.1086/185931",
         "description": "ESO 207-61: A Brown Dwarf Candidate in the Hyades Moving Grou"
     },
     {
-        "name": "Sali03",
+        "publication": "Sali03",
         "bibcode": "2003ApJ...586L.149S",
         "doi": "10.1086/374794",
         "description": "LSR 0602+3910: Discovery of a Bright Nearby L-Type Brown Dwarf"
     },
     {
-        "name": "Schi09",
+        "publication": "Schi09",
         "bibcode": "2009A&A...493L..27S",
         "doi": "10.1051/0004-6361:200811281",
         "description": "Trigonometric parallaxes of ten ultracool subdwarfs"
     },
     {
-        "name": "Schm07",
+        "publication": "Schm07",
         "bibcode": "2007AJ....133.2258S",
         "doi": "10.1086/512158",
         "description": "Activity and Kinematics of Ultracool Dwarfs, Including an Amazing Flare Observation"
     },
     {
-        "name": "Schn02",
+        "publication": "Schn02",
         "bibcode": "2002AJ....123..458S",
         "doi": "10.1086/338095",
         "description": "L Dwarfs Found in Sloan Digital Sky Survey Commissioning Data. II. Hobby-Eberly Telescope Observations"
     },
     {
-        "name": "Scho03",
+        "publication": "Scho03",
         "bibcode": "2003A&A...398L..29S",
         "doi": "10.1051/0004-6361:20021847",
         "description": "varepsilon  Indi B: A new benchmark T dwarf"
     },
     {
-        "name": "Scho04a",
+        "publication": "Scho04a",
         "bibcode": "2004A&A...425..519S",
         "doi": "10.1051/0004-6361:20041059",
         "description": "The nearest cool white dwarf (d {\\tilde}4 pc), the coolest M-type subdwarf (sdM9.5), and other high proper motion discoveries"
     },
     {
-        "name": "Scho04b",
+        "publication": "Scho04b",
         "bibcode": "2004MNRAS.347..685S",
         "doi": "10.1111/j.1365-2966.2004.07252.x",
         "description": "An active M8.5 dwarf wide companion to the M4/DA binary LHS 4039/LHS 4040"
     },
     {
-        "name": "Scho04c",
+        "publication": "Scho04c",
         "bibcode": "2004A&A...428L..25S",
         "doi": "10.1051/0004-6361:200400098",
         "description": "SSSPM J1444-2019: An extremely high proper motion, ultracool subdwarf"
     },
     {
-        "name": "Scho05",
+        "publication": "Scho05",
         "bibcode": "2005A&A...430L..49S",
         "doi": "10.1051/0004-6361:200400121",
         "description": "SSSPM J1102-3431: A probable new young brown dwarf member of the TW Hydrae Association"
     },
     {
-        "name": "Scho09",
+        "publication": "Scho09",
         "bibcode": "2009A&A...494..949S",
         "doi": "10.1051/0004-6361:200811053",
         "description": "Extremely faint high proper motion objects from SDSS stripe 82. Optical classification spectroscopy of about 40 new objects"
     },
     {
-        "name": "Scho10a",
+        "publication": "Scho10a",
         "bibcode": "2010A&A...515A..92S",
         "doi": "10.1051/0004-6361/201014264",
         "description": "Hip 63510C, Hip 73786B, and nine new isolated high proper motion T dwarf candidates from UKIDSS DR6 and SDSS DR7"
     },
     {
-        "name": "Scho10b",
+        "publication": "Scho10b",
         "bibcode": "2010A&A...510L...8S",
         "doi": "10.1051/0004-6361/201014078",
         "description": "ULAS J141623.94+134836.3 - a faint common proper motion companion of a nearby L dwarf. Serendipitous discovery of a cool brown dwarf in UKIDSS DR6"
     },
     {
-        "name": "Scho11",
+        "publication": "Scho11",
         "bibcode": "2011A&A...532L...5S",
         "doi": "10.1051/0004-6361/201117297",
         "description": "Two very nearby (d ~ 5 pc) ultracool brown dwarfs detected by their large proper motions from WISE, 2MASS, and SDSS data"
     },
     {
-        "name": "Schr00",
+        "publication": "Schr00",
         "bibcode": "2000AJ....119..906S",
         "doi": "10.1086/301227",
         "description": "A Search for Faint Companions to Nearby Stars Using the Wide Field Planetary Camera 2"
     },
     {
-        "name": "Seif04",
+        "publication": "Seif04",
         "bibcode": "2004A&A...421..255S",
         "doi": "10.1051/0004-6361:20041159",
         "description": "Astrometric proof of companionship  for the L dwarf companion candidate GJ1048B"
     },
     {
-        "name": "Shko09",
+        "publication": "Shko09",
         "bibcode": "2009ApJ...699..649S",
         "doi": "10.1088/0004-637X/699/1/649",
         "description": "Identifying the Young Low-mass Stars within 25 pc. I. Spectroscopic Observations"
     },
     {
-        "name": "Sieg03",
+        "publication": "Sieg03",
         "bibcode": "2003ApJ...598.1265S",
         "doi": "10.1086/378935",
         "description": "An Adaptive Optics Survey of M6.0-M7.5 Stars: Discovery of Three Very Low Mass Binary Systems Including Two Probable Hyades Members"
     },
     {
-        "name": "Sieg05",
+        "publication": "Sieg05",
         "bibcode": "2005ApJ...621.1023S",
         "doi": "10.1086/427743",
         "description": "Discovery of Two Very Low Mass Binaries: Final Results of an Adaptive Optics Survey of Nearby M6.0-M7.5 Stars"
     },
     {
-        "name": "Sieg07",
+        "publication": "Sieg07",
         "bibcode": "2007AJ....133.2320S",
         "doi": "10.1086/513273",
         "description": "Discovery of a 66 mas Ultracool Binary with Laser Guide Star Adaptive Optics"
     },
     {
-        "name": "Simo06",
+        "publication": "Simo06",
         "bibcode": "2006ApJ...644.1183S",
         "doi": "10.1086/503867",
         "description": "The Gl569 Multiple System"
     },
     {
-        "name": "Siva09",
+        "publication": "Siva09",
         "bibcode": "2009ApJ...694L.140S",
         "doi": "10.1088/0004-637X/694/2/L140",
         "description": "SDSS J125637-022452: A High Proper Motion L Subdwarf"
     },
     {
-        "name": "Smar10",
+        "publication": "Smar10",
         "bibcode": "2010A&A...511A..30S",
         "doi": "10.1051/0004-6361/200913633",
         "description": "The distance to the cool T9 brown dwarf ULAS J003402.77-005206.7"
     },
     {
-        "name": "Song06",
+        "publication": "Song06",
         "bibcode": "2006ApJ...652..724S",
         "doi": "10.1086/507831",
         "description": "HST NICMOS Imaging of the Planetary-mass Companion to the Young Brown Dwarf 2MASSW J1207334-393254"
     },
     {
-        "name": "Stra99",
+        "publication": "Stra99",
         "bibcode": "1999ApJ...522L..61S",
         "doi": "10.1086/312218",
         "description": "The Discovery of a Field Methane Dwarf from Sloan Digital Sky Survey Commissioning Data"
     },
     {
-        "name": "Stum10",
+        "publication": "Stum10",
         "bibcode": "2010ApJ...724....1S",
         "doi": "10.1088/0004-637X/724/1/1",
         "description": "The Search for Planetary Mass Companions to Field Brown Dwarfs with HST/NICMOS"
     },
     {
-        "name": "Stum11",
+        "publication": "Stum11",
         "bibcode": "2011A&A...525A.123S",
         "doi": "10.1051/0004-6361/201015392",
         "description": "Resolving the L/T transition binary SDSS J2052-1609 AB"
     },
     {
-        "name": "Suba09",
+        "publication": "Suba09",
         "bibcode": "2009AJ....137.4547S",
         "doi": "10.1088/0004-6256/137/6/4547",
         "description": "The Solar Neighborhood. XXI. Parallax Results from the CTIOPI 0.9 m Program: 20 New Members of the 25 Parsec White Dwarf Sample"
     },
     {
-        "name": "Teix08",
+        "publication": "Teix08",
         "bibcode": "2008A&A...489..825T",
         "doi": "10.1051/0004-6361:200810133",
         "description": "SSSPM J1102-3431 brown dwarf characterization from accurate proper motion and trigonometric parallax"
     },
     {
-        "name": "Thal09",
+        "publication": "Thal09",
         "bibcode": "2009ApJ...707L.123T",
         "doi": "10.1088/0004-637X/707/2/L123",
         "description": "Discovery of the Coldest Imaged Companion of a Sun-like Star"
     },
     {
-        "name": "Thor03",
+        "publication": "Thor03",
         "bibcode": "2003PASP..115.1207T",
         "doi": "10.1086/378080",
         "description": "Serendipitous Discovery and Parallax of a Nearby L Dwarf"
     },
     {
-        "name": "Tinn95",
+        "publication": "Tinn95",
         "bibcode": "1995AJ....110.3014T",
         "doi": "10.1086/117743",
         "description": "Trigonometric Parallaxes and the HR Diagram at the Bottom of the Main Sequence"
     },
     {
-        "name": "Tinn96",
+        "publication": "Tinn96",
         "bibcode": "1996MNRAS.281..644T",
         "doi": "10.1093/mnras/281.2.644",
         "description": "CCD astrometry of southern very low-mass stars"
     },
     {
-        "name": "Tinn98",
+        "publication": "Tinn98",
         "bibcode": "1998MNRAS.301.1031T",
         "doi": "10.1046/j.1365-8711.1998.02079.x",
         "description": "High-resolution spectra of very low-mass stars"
     },
     {
-        "name": "Tinn03",
+        "publication": "Tinn03",
         "bibcode": "2003AJ....126..975T",
         "doi": "10.1086/376481",
         "description": "Infrared Parallaxes for Methane T Dwarfs"
     },
     {
-        "name": "Tsve00",
+        "publication": "Tsve00",
         "bibcode": "2000ApJ...531L..61T",
         "doi": "10.1086/312515",
         "description": "The Discovery of a Second Field Methane Brown Dwarf from Sloan Digital Sky Survey Commissioning Data"
     },
     {
-        "name": "vanA95",
+        "publication": "vanA95",
         "bibcode": "1995gcts.book.....V",
         "doi": null,
         "description": "The general catalogue of trigonometric [stellar] parallaxes"
     },
     {
-        "name": "vanL07",
+        "publication": "vanL07",
         "bibcode": "2007A&A...474..653V",
         "doi": "10.1051/0004-6361:20078357",
         "description": "Validation of the new Hipparcos reduction"
     },
     {
-        "name": "Vrba04",
+        "publication": "Vrba04",
         "bibcode": "2004AJ....127.2948V",
         "doi": "10.1086/383554",
         "description": "Preliminary Parallaxes of 40 L and T Dwarfs from the US Naval Observatory Infrared Astrometry Program"
     },
     {
-        "name": "Warr07",
+        "publication": "Warr07",
         "bibcode": "2007MNRAS.381.1400W",
         "doi": "10.1111/j.1365-2966.2007.12348.x",
         "description": "A very cool brown dwarf in UKIDSS DR1"
     },
     {
-        "name": "West08",
+        "publication": "West08",
         "bibcode": "2008AJ....135..785W",
         "doi": "10.1088/0004-6256/135/3/785",
         "description": "Constraining the Age-Activity Relation for Cool Stars: The Sloan Digital Sky Survey Data Release 5 Low-Mass Star Spectroscopic Sample"
     },
     {
-        "name": "Wils01",
+        "publication": "Wils01",
         "bibcode": "2001AJ....122.1989W",
         "doi": "10.1086/323134",
         "description": "Three Wide-Separation L Dwarf Companions from the Two Micron All Sky Survey: Gliese 337C, Gliese 618.1B, and HD 89744B"
     },
     {
-        "name": "Wils03",
+        "publication": "Wils03",
         "bibcode": "2003IAUS..211..197W",
         "doi": null,
         "description": "New M and L Dwarfs Confirmed with CorMASS"
     },
     {
-        "name": "Zapa04",
+        "publication": "Zapa04",
         "bibcode": "2004astro.ph..7334O",
         "doi": null,
         "description": "Dynamical Masses of the Binary Brown Dwarf GJ 569Bab"
     },
     {
-        "name": "Zapa10",
+        "publication": "Zapa10",
         "bibcode": "2010ApJ...715.1408Z",
         "doi": "10.1088/0004-637X/715/2/1408",
         "description": "Infrared and Kinematic Properties of the Substellar Object G 196-3 B"
     },
     {
-        "name": "Reid00",
+        "publication": "Reid00",
         "bibcode": "2000AJ....119..369R",
         "doi": "10.1086/301177",
         "description": "Four Nearby L Dwarfs"
     },
     {
-        "name": "Burg06b",
+        "publication": "Burg06b",
         "bibcode": "2006ApJ...637.1067B",
         "doi": "10.1086/498563",
         "description": "A Unified Near-Infrared Spectral Classification Scheme for T Dwarfs"
     },
     {
-        "name": "Burg08T",
+        "publication": "Burg08T",
         "bibcode": "2008PhT....61f..70B",
         "doi": "10.1063/1.2947658",
         "description": "Brown dwarfs: Failed stars, super Jupiters"
     },
     {
-        "name": "Lieb07",
+        "publication": "Lieb07",
         "bibcode": "2007ApJ...655..522L",
         "doi": "10.1086/509882",
         "description": "On the Nature of the Unique Ha-emitting T Dwarf 2MASS J12373919+6526148"
     },
     {
-        "name": "Kirk10",
+        "publication": "Kirk10",
         "bibcode": "2010ApJS..190..100K",
         "doi": "10.1088/0067-0049/190/1/100",
         "description": "Discoveries from a Near-infrared Proper Motion Survey Using Multi-epoch Two Micron All-Sky Survey Data"
     },
     {
-        "name": "YoungList",
+        "publication": "YoungList",
         "bibcode": null,
         "doi": null,
         "description": null
     },
     {
-        "name": "Diet14",
+        "publication": "Diet14",
         "bibcode": "2014AJ....147...94D",
         "doi": "10.1088/0004-6256/147/5/94",
         "description": "The Solar Neighborhood. XXXII. The Hydrogen Burning Limit"
     },
     {
-        "name": "Mama13",
+        "publication": "Mama13",
         "bibcode": "2013AJ....146..154M",
         "doi": "10.1088/0004-6256/146/6/154",
         "description": "The Solar Neighborhood. XXX. Fomalhaut C"
     },
     {
-        "name": "Hog_00",
+        "publication": "Hog_00",
         "bibcode": "2000A&A...355L..27H",
         "doi": null,
         "description": "The Tycho-2 catalogue of the 2.5 million brightest stars"
     },
     {
-        "name": "Zach12",
+        "publication": "Zach12",
         "bibcode": "2012yCat.1322....0Z",
         "doi": null,
         "description": "The fourth US Naval Observatory CCD Astrograph Catalog (UCAC4)"
     },
     {
-        "name": "Kira12",
+        "publication": "Kira12",
         "bibcode": "2012AcA....62...67K",
         "doi": null,
         "description": "ASAS photometry of ROSAT sources. I. Periodic variable stars coincident with bright sources from the ROSAT All Sky Survey"
     },
     {
-        "name": "Lieb06",
+        "publication": "Lieb06",
         "bibcode": "2006PASP..118..659L",
         "doi": "10.1086/503333",
         "description": "RI photometry of 2MASS-selected late M and L dwarfs"
     },
     {
-        "name": "Bonn14b",
+        "publication": "Bonn14b",
         "bibcode": "2014A&A...562A.127B",
         "doi": "10.1051/0004-6361/201118270",
         "description": "A library of near-infrared integral field spectra of young M-L dwarfs"
     },
     {
-        "name": "Ahn_12",
+        "publication": "Ahn_12",
         "bibcode": "2012ApJS..203...21A",
         "doi": "10.1088/0067-0049/203/2/21",
         "description": "The Ninth Data Release of the Sloan Digital Sky Survey: First Spectroscopic Data from the SDSS-III Baryon Oscillation Spectroscopic Survey"
     },
     {
-        "name": "Kirk94a",
+        "publication": "Kirk94a",
         "bibcode": "1994AJ....107..333K",
         "doi": "10.1086/116856",
         "description": "Low mass companions to nearby stars: Spectral classification and its relation to the stellar/substellar break"
     },
     {
-        "name": "FaheSubm",
+        "publication": "FaheSubm",
         "bibcode": null,
         "doi": null,
         "description": null
     },
     {
-        "name": "Mana13",
+        "publication": "Mana13",
         "bibcode": "2013A&A...551A.107M",
         "doi": "10.1051/0004-6361/201220921",
         "description": "X-shooter spectroscopy of young stellar objects. II. Impact of chromospheric emission on accretion rate estimates"
     },
     {
-        "name": "Fahe09",
+        "publication": "Fahe09",
         "bibcode": "2009AJ....137....1F",
         "doi": "10.1088/0004-6256/137/1/1",
         "description": "The Brown Dwarf Kinematics Project I. Proper Motions and Tangential Velocities for a Large Sample of Late-Type M, L, and T Dwarfs"
     },
     {
-        "name": "Boff14",
+        "publication": "Boff14",
         "bibcode": "2014A&A...561L...4B",
         "doi": "10.1051/0004-6361/201322975",
         "description": "Possible astrometric discovery of a substellar companion to the closest binary brown dwarf system WISE J104915.57-531906.1"
     },
     {
-        "name": "Fahe14",
+        "publication": "Fahe14",
         "bibcode": "2014ApJ...790...90F",
         "doi": "10.1088/0004-637X/790/2/90",
         "description": "Signatures of Cloud, Temperature, and Gravity from Spectra of the Closest Brown Dwarfs"
     },
     {
-        "name": "Dupu13",
+        "publication": "Dupu13",
         "bibcode": "2013Sci...341.1492D",
         "doi": "10.1126/science.1241917",
         "description": "Distances, Luminosities, and Temperatures of the Coldest Known Substellar Objects"
     },
     {
-        "name": "Manj14",
+        "publication": "Manj14",
         "bibcode": "2014A&A...564A..55M",
         "doi": "10.1051/0004-6361/201323016",
         "description": "New constraints on the formation and settling of dust in the atmospheres of young M and L dwarfs"
     },
     {
-        "name": "Berg06",
+        "publication": "Berg06",
         "bibcode": "2006ApJ...648..629B",
         "doi": "10.1086/505787",
         "description": "Radio Observations of a Large Sample of Late M, L, and T Dwarfs: The Distribution of Magnetic Field Strengths"
     },
     {
-        "name": "Cese13",
+        "publication": "Cese13",
         "bibcode": "2013A&A...549A.129C",
         "doi": "10.1051/0004-6361/201219078",
         "description": "The Infrared Telescope Facility (IRTF) spectral library:. Spectral diagnostics for cool stars"
     },
     {
-        "name": "Cush06b",
+        "publication": "Cush06b",
         "bibcode": "2006ApJ...648..614C",
         "doi": "10.1086/505637",
         "description": "A Spitzer Infrared Spectrograph Spectral Sequence of M, L, and T Dwarfs"
     },
     {
-        "name": "Perr97",
+        "publication": "Perr97",
         "bibcode": "1997A&A...323L..49P",
         "doi": null,
         "description": "The HIPPARCOS Catalogue"
     },
     {
-        "name": "Jenk09",
+        "publication": "Jenk09",
         "bibcode": "2009ApJ...704..975J",
         "doi": "10.1088/0004-637X/704/2/975",
         "description": "Rotational Velocities for M Dwarfs"
     },
     {
-        "name": "Delf97",
+        "publication": "Delf97",
         "bibcode": "1997A&A...327L..25D",
         "doi": null,
         "description": "Field brown dwarfs found by DENIS"
     },
     {
-        "name": "Abaz09",
+        "publication": "Abaz09",
         "bibcode": "2009ApJS..182..543A",
         "doi": "10.1088/0067-0049/182/2/543",
         "description": "The Seventh Data Release of the Sloan Digital Sky Survey"
     },
     {
-        "name": "Ardi10",
+        "publication": "Ardi10",
         "bibcode": "2010ApJS..191..301A",
         "doi": "10.1088/0067-0049/191/2/301",
         "description": "The Spitzer Atlas of Stellar Spectra (SASS)"
     },
     {
-        "name": "Cutr13",
+        "publication": "Cutr13",
         "bibcode": "2014yCat.2328....0C",
         "doi": "",
         "description": "VizieR Online Data Catalog: AllWISE Data Release (Cutri+ 2013)"
     },
     {
-        "name": "Kirk05",
+        "publication": "Kirk05",
         "bibcode": "2005ARA&A..43..195K",
         "doi": "10.1146/annurev.astro.42.053102.134017",
         "description": "New Spectral Types L and T"
     },
     {
-        "name": "Bian11",
+        "publication": "Bian11",
         "bibcode": "2011Ap&SS.335..161B",
         "doi": "10.1007/s10509-010-0581-x",
         "description": "GALEX catalogs of UV sources: statistical properties and sample science applications: hot white dwarfs in the Milky Way"
     },
     {
-        "name": "Smar13",
+        "publication": "Smar13",
         "bibcode": "2013MNRAS.433.2054S",
         "doi": "10.1093/mnras/stt876",
         "description": "NPARSEC: NTT Parallaxes of Southern Extremely Cool objects. Goals, targets, procedures and first results"
     },
     {
-        "name": "Zapa14a",
+        "publication": "Zapa14a",
         "bibcode": "2014A&A...568A...6Z",
         "doi": "10.1051/0004-6361/201321340",
         "description": "Trigonometric parallaxes of young field L dwarfs"
     },
     {
-        "name": "Zhan10",
+        "publication": "Zhan10",
         "bibcode": "2010MNRAS.404.1817Z",
         "doi": "10.1111/j.1365-2966.2010.16394.x",
         "description": "Discovery of the first wide L dwarf + giant binary system and eight other ultracool dwarfs in wide binaries"
     },
     {
-        "name": "Shep09",
+        "publication": "Shep09",
         "bibcode": "2009AJ....137..304S",
         "doi": "10.1088/0004-6256/137/1/304",
         "description": "An Infrared High Proper Motion Survey Using the 2MASS and SDSS: Discovery of M, L, and T Dwarfs"
     },
     {
-        "name": "Main11",
+        "publication": "Main11",
         "bibcode": "2011ApJ...726...30M",
         "doi": "10.1088/0004-637X/726/1/30",
         "description": "The First Ultra-cool Brown Dwarf Discovered by the Wide-field Infrared Survey Explorer"
     },
     {
-        "name": "Mace13",
+        "publication": "Mace13",
         "bibcode": "2013ApJS..205....6M",
         "doi": "10.1088/0067-0049/205/1/6",
         "description": "A Study of the Diverse T Dwarf Population Revealed by WISE"
     },
     {
-        "name": "Adel08",
+        "publication": "Adel08",
         "bibcode": "2008ApJS..175..297A",
         "doi": "10.1086/524984",
         "description": "The Sixth Data Release of the Sloan Digital Sky Survey"
     },
     {
-        "name": "Liu_13b",
+        "publication": "Liu_13b",
         "bibcode": "2013ApJ...777L..20L",
         "doi": "10.1088/2041-8205/777/2/L20",
         "description": "The Extremely Red, Young L Dwarf PSO J318.5338-22.8603: A Free-floating Planetary-mass Analog to Directly Imaged Young Gas-giant Planets"
     },
     {
-        "name": "Gizi12",
+        "publication": "Gizi12",
         "bibcode": "2012AJ....144...94G",
         "doi": "10.1088/0004-6256/144/4/94",
         "description": "Discovery of an Unusually Red L-type Brown Dwarf"
     },
     {
-        "name": "Maro13",
+        "publication": "Maro13",
         "bibcode": "2013AJ....146..161M",
         "doi": "10.1088/0004-6256/146/6/161",
         "description": "Parallaxes of Southern Extremely Cool Objects (PARSEC). II. Spectroscopic Follow-up and Parallaxes of 52 Targets"
     },
     {
-        "name": "Gizi15",
+        "publication": "Gizi15",
         "bibcode": "2015ApJ...799..203G",
         "doi": "10.1088/0004-637X/799/2/203",
         "description": "WISEP J004701.06+680352.1: An Intermediate Surface Gravity, Dusty Brown Dwarf in the AB Dor Moving Group"
     },
     {
-        "name": "Lodi12",
+        "publication": "Lodi12",
         "bibcode": "2012A&A...548A..53L ",
         "doi": "10.1051/0004-6361/201220182",
         "description": "First T dwarfs in the VISTA Hemisphere Survey"
     },
     {
-        "name": "Irwi91",
+        "publication": "Irwi91",
         "bibcode": "1991MNRAS.252P..61I",
         "doi": "10.1093/mnras/252.1.61P",
         "description": "A star of exceedingly low luminosity"
     },
     {
-        "name": "Tinn93c",
+        "publication": "Tinn93c",
         "bibcode": "1993AJ....105.1169T",
         "doi": "10.1086/116501",
         "description": "The faintest stars - Trigonometric CCD parallaxes"
     },
     {
-        "name": "Tinn93b",
+        "publication": "Tinn93b",
         "bibcode": "1993ApJ...414..279T ",
         "doi": "10.1086/173075",
         "description": "The faintest stars - The luminosity and mass functions at the bottom of the main sequence"
     },
     {
-        "name": "Ruiz97",
+        "publication": "Ruiz97",
         "bibcode": "1997ApJ...491L.107R",
         "doi": "10.1086/311070",
         "description": "Kelu-1 : A Free-floating Brown Dwarf in the Solar Neighborhood"
     },
     {
-        "name": "Mart98",
+        "publication": "Mart98",
         "bibcode": "1998ApJ...507L..41M  ",
         "doi": "10.1086/311675",
         "description": "The First L-Type Brown Dwarf in the Pleiades"
     },
     {
-        "name": "Rebo98",
+        "publication": "Rebo98",
         "bibcode": "1998Sci...282.1309R",
         "doi": "10.1126/science.282.5392.1309",
         "description": "Discovery of a Low-Mass Brown Dwarf Companion of the Young Nearby Star G 196-3"
     },
     {
-        "name": "Gold99",
+        "publication": "Gold99",
         "bibcode": "1999A&A...351L...5G",
         "doi": null,
         "description": "EROS 2 proper motion survey: a field brown dwarf, and an L dwarf companion to LHS 102"
     },
     {
-        "name": "Lodi02",
+        "publication": "Lodi02",
         "bibcode": "2002A&A...389L..20L",
         "doi": "10.1051/0004-6361:20020698",
         "description": "Discovery of three nearby L dwarfs in the Southern Sky"
     },
     {
-        "name": "Cruz02",
+        "publication": "Cruz02",
         "bibcode": "2002AJ....123.2828C",
         "doi": "10.1086/339973",
         "description": "Meeting the Cool Neighbors. III. Spectroscopy of Northern NLTT Stars"
     },
     {
-        "name": "Curr14",
+        "publication": "Curr14",
         "bibcode": "2014ApJ...795..133C",
         "doi": "10.1088/0004-637X/795/2/133",
         "description": "DEEP THERMAL INFRARED IMAGING OF HR 8799 bcde: NEW ATMOSPHERIC CONSTRAINTS AND LIMITS ON A FIFTH PLANET"
     },
     {
-        "name": "Dobb02",
+        "publication": "Dobb02",
         "bibcode": "2002MNRAS.329..543D",
         "doi": "10.1046/j.1365-8711.2002.05002.x",
         "description": "A deep large-area search for very low-mass members of the Hyades open cluster"
     },
     {
-        "name": "Wils02",
+        "publication": "Wils02",
         "bibcode": "2002PhDT........19W",
         "doi": null,
         "description": "Near-infrared spectroscopy of low mass stars and brown dwarfs"
     },
     {
-        "name": "Kend03",
+        "publication": "Kend03",
         "bibcode": "2003A&A...403..929K",
         "doi": "10.1051/0004-6361:20030218",
         "description": "Serendipitous discovery of seven new southern L-dwarfs"
     },
     {
-        "name": "Lieb03",
+        "publication": "Lieb03",
         "bibcode": "2003AJ....125..343L",
         "doi": "10.1086/345514",
         "description": "A Flaring L5 Dwarf: The Nature of Ha Emission in Very Low Mass (Sub)Stellar Objects"
     },
     {
-        "name": "Luhm04",
+        "publication": "Luhm04",
         "bibcode": "2004ApJ...617.1216L",
         "doi": "10.1086/425647",
         "description": "New Brown Dwarfs and an Updated Initial Mass Function in Taurus"
     },
     {
-        "name": "Cruz04PhD",
+        "publication": "Cruz04PhD",
         "bibcode": "2004PhDT........17C",
         "doi": null,
         "description": "The luminosity function of low-mass stars and brown dwarfs"
     },
     {
-        "name": "Arti06",
+        "publication": "Arti06",
         "bibcode": "2006ApJ...651L..57A",
         "doi": "10.1086/509146",
         "description": "Discovery of the Brightest T Dwarf in the Northern Hemisphere"
     },
     {
-        "name": "Kirk99b",
+        "publication": "Kirk99b",
         "bibcode": "1999ApJ...519..834K",
         "doi": "10.1086/307380",
         "description": "An Improved Optical Spectrum and New Model FITS of the Likely Brown Dwarf GD 165B"
     },
     {
-        "name": "McCa04",
+        "publication": "McCa04",
         "bibcode": "2004A&A...413.1029M",
         "doi": "10.1051/0004-6361:20034292",
         "description": "eps Indi Ba,Bb: The nearest binary brown dwarf"
     },
     {
-        "name": "Deac07",
+        "publication": "Deac07",
         "bibcode": "2007A&A...468..163D",
         "doi": "10.1051/0004-6361:20066844",
         "description": "Southern infrared proper motion survey. II. A sample of low mass stars with {$\\mu$} {\\ge} 0.1''/ yr"
     },
     {
-        "name": "Folk07PhD",
+        "publication": "Folk07PhD",
         "bibcode": "2007JPhA...40.8247D",
         "doi": "10.1088/1751-8113/40/29/004",
         "description": "Model C critical dynamics of random anisotropy magnets"
     },
     {
-        "name": "Metc08",
+        "publication": "Metc08",
         "bibcode": "2008ApJ...676.1281M",
         "doi": "10.1086/524721",
         "description": "A Cross-Match of 2MASS and SDSS: Newly Found L and T Dwarfs and an Estimate of the Space Density of T Dwarfs"
     },
     {
-        "name": "Radi08",
+        "publication": "Radi08",
         "bibcode": "2008ApJ...689..471R",
         "doi": "10.1086/592379",
         "description": "Discovery of a Wide Substellar Companion to a Nearby Low-Mass Star"
     },
     {
-        "name": "Phan08",
+        "publication": "Phan08",
         "bibcode": "2008MNRAS.383..831P",
         "doi": "10.1111/j.1365-2966.2007.12564.x",
         "description": "Discovery of new nearby L and late-M dwarfs at low Galactic latitude from the DENIS data base"
     },
     {
-        "name": "Zhan09",
+        "publication": "Zhan09",
         "bibcode": "2009A&A...497..619Z",
         "doi": "10.1051/0004-6361/200810314",
         "description": "Ultra-cool dwarfs: new discoveries, proper motions, and improved spectral typing from SDSS and 2MASS photometric colors"
     },
     {
-        "name": "CruzUnpub",
+        "publication": "CruzUnpub",
         "bibcode": "",
         "doi": null,
         "description": "Kelle has data but it's not in a publication"
     },
     {
-        "name": "Delo12",
+        "publication": "Delo12",
         "bibcode": "2012A&A...548A..26D",
         "doi": "10.1051/0004-6361/201219984",
         "description": "CFBDSIR2149-0403: a 4-7 Jupiter-mass free-floating planet in the young moving group AB Doradus?"
     },
     {
-        "name": "Gagn14a",
+        "publication": "Gagn14a",
         "bibcode": "2014ApJ...783..121G",
         "doi": "10.1088/0004-637X/783/2/121",
         "description": "BANYAN. II. Very Low Mass and Substellar Candidate Members to Nearby, Young Kinematic Groups with Previously Known Signs of Youth"
     },
     {
-        "name": "Gagn14b",
+        "publication": "Gagn14b",
         "bibcode": "2014ApJ...785L..14G",
         "doi": "10.1088/2041-8205/785/1/L14",
         "description": "The Coolest Isolated Brown Dwarf Candidate Member of TWA"
     },
     {
-        "name": "Gagn14c",
+        "publication": "Gagn14c",
         "bibcode": "2014ApJ...792L..17G",
         "doi": "10.1088/2041-8205/792/1/L17",
         "description": "SIMP J2154-1055: A New Low-gravity L4beta Brown Dwarf Candidate Member of the Argus Association"
     },
     {
-        "name": "Schn14",
+        "publication": "Schn14",
         "bibcode": "2014AJ....147...34S",
         "doi": "10.1088/0004-6256/147/2/34",
         "description": "Discovery of the Young L Dwarf WISE J174102.78-464225.5"
     },
     {
-        "name": "Lawr07",
+        "publication": "Lawr07",
         "bibcode": "2007MNRAS.379.1599L",
         "doi": "10.1111/j.1365-2966.2007.12040.x",
         "description": "The UKIRT Infrared Deep Sky Survey (UKIDSS)"
     },
     {
-        "name": "Rayn09",
+        "publication": "Rayn09",
         "bibcode": "2009ApJS..185..289R",
         "doi": "10.1088/0067-0049/185/2/289",
         "description": "The Infrared Telescope Facility (IRTF) Spectral Library: Cool Stars"
     },
     {
-        "name": "Geli14",
+        "publication": "Geli14",
         "bibcode": "2014AJ....148....6G",
         "doi": "10.1088/0004-6256/148/1/6",
         "description": "WISEP J061135.13-041024.0 AB: A J-band Flux Reversal Binary at the L/T Transition"
     },
     {
-        "name": "Wein13",
+        "publication": "Wein13",
         "bibcode": "2013ApJ...762..118W",
         "doi": "10.1088/0004-637X/762/2/118",
         "description": "Distance and Kinematics of the TW Hydrae Association from Parallaxes"
     },
     {
-        "name": "Alle07a",
+        "publication": "Alle07a",
         "bibcode": "2007ApJ...657..511A",
         "doi": "10.1086/510845",
         "description": "Characterizing Young Brown Dwarfs Using Low-Resolution Near-Infrared Spectra"
     },
     {
-        "name": "Burg08c",
+        "publication": "Burg08c",
         "bibcode": "2008ApJ...674..451B",
         "doi": "10.1086/524726",
         "description": "Clouds, Gravity, and Metallicity in Blue L Dwarfs: The Case of 2MASS J11263991-5003550"
     },
     {
-        "name": "Burg07b",
+        "publication": "Burg07b",
         "bibcode": "2007ApJ...658..557B",
         "doi": "10.1086/511518",
         "description": "Discovery of a High Proper Motion L Dwarf Binary: 2MASS J15200224-4422419AB"
     },
     {
-        "name": "Maci15",
+        "publication": "Maci15",
         "bibcode": "2015Sci...350...64M",
         "doi": "10.1126/science.aac5891",
         "description": "Discovery and spectroscopy of the young jovian planet 51 Eri b with the Gemini Planet Imager"
     },
     {
-        "name": "Dupu12a",
+        "publication": "Dupu12a",
         "bibcode": "2012ApJS..201...19D",
         "doi": "10.1088/0067-0049/201/2/19",
         "description": "The Hawaii Infrared Parallax Program. I. Ultracool Binaries and the L/T Transition"
     },
     {
-        "name": "Burg10b",
+        "publication": "Burg10b",
         "bibcode": "2010AJ....139.2448B",
         "doi": "10.1088/0004-6256/139/6/2448",
         "description": "ULAS J141623.94+134836.3: A Blue T Dwarf Companion to a Blue L Dwarf"
     },
     {
-        "name": "Ruiz01",
+        "publication": "Ruiz01",
         "bibcode": "2001ApJS..133..119R",
         "doi": "10.1086/319188",
         "description": "Cal\u00e1n-ESO Proper-Motion Catalog"
     },
     {
-        "name": "Phan03",
+        "publication": "Phan03",
         "bibcode": "2003A&A...401..959P",
         "doi": "10.1051/0004-6361:20030188",
         "description": "New neighbours. V. 35 DENIS late-M dwarfs between 10 and 30 parsecs"
     },
     {
-        "name": "Luyt79a",
+        "publication": "Luyt79a",
         "bibcode": "1979lccs.book.....L",
         "doi": null,
         "description": "Luyten Half-Second Catalog"
     },
     {
-        "name": "Luyt79b",
+        "publication": "Luyt79b",
         "bibcode": "1979nlcs.book.....L",
         "doi": null,
         "description": "New Luyten Two-Tenths Catalog"
     },
     {
-        "name": "Poko04",
+        "publication": "Poko04",
         "bibcode": "2004A&A...421..763P",
         "doi": "10.1051/0004-6361:20047009",
         "description": "The Liverpool-Edinburgh high proper motion catalogue"
     },
     {
-        "name": "Reyl04",
+        "publication": "Reyl04",
         "bibcode": "2004A&A...421..643R",
         "doi": "10.1051/0004-6361:20034553",
         "description": "New nearby stars in the Liverpool-Edinburgh high proper motion survey selected by DENIS photometry"
     },
     {
-        "name": "Stas06",
+        "publication": "Stas06",
         "bibcode": "2006Natur.440..311S",
         "doi": "10.1038/nature04570",
         "description": "Discovery of two young brown dwarfs in an eclipsing binary system"
     },
     {
-        "name": "Cant13",
+        "publication": "Cant13",
         "bibcode": "2013MNRAS.435.2650C",
         "doi": "10.1093/mnras/stt1477",
         "description": "Towards precise ages and masses of Free Floating Planetary Mass Brown Dwarfs"
     },
     {
-        "name": "Pati12",
+        "publication": "Pati12",
         "bibcode": "2012A&A...540A..85P",
         "doi": "10.1051/0004-6361/201118058",
         "description": "Spectroscopy across the brown dwarf/planetary mass boundary. I. Near-infrared JHK spectra"
     },
     {
-        "name": "Schm14",
+        "publication": "Schm14",
         "bibcode": "2014PASP..126..642S",
         "doi": "10.1086/677403",
         "description": "Calibrating Ultracool Dwarfs: Optical Template Spectra, Bolometric Corrections, and {$\\chi$} Values"
     },
     {
-        "name": "Burn13",
+        "publication": "Burn13",
         "bibcode": "2013MNRAS.433..457B",
         "doi": "10.1093/mnras/stt740",
         "description": "76 T dwarfs from the UKIDSS LAS: benchmarks, kinematics and an updated space density"
     },
     {
-        "name": "Legg12",
+        "publication": "Legg12",
         "bibcode": "2012ApJ...748...74L",
         "doi": "10.1088/0004-637X/748/2/74",
         "description": "The Properties of the 500 K Dwarf UGPS J072227.51-054031.2 and a Study of the Far-red Flux of Cold Brown Dwarfs"
     },
     {
-        "name": "Burg00b",
+        "publication": "Burg00b",
         "bibcode": "2000AJ....120..473B",
         "doi": "10.1086/301423",
         "description": "Detection of Ha Emission in a Methane (T Type) Brown Dwarf"
     },
     {
-        "name": "Loop07b",
+        "publication": "Loop07b",
         "bibcode": "2007ApJ...669L..97L",
         "doi": "10.1086/523812",
         "description": "Discovery of an M9.5 candidate brown dwarf in the TW Hydrae association: DENIS J124514.1-442907"
     },
     {
-        "name": "Oke_95",
+        "publication": "Oke_95",
         "bibcode": "1995PASP..107..375O",
         "doi": "10.1086/133562",
         "description": "The Keck Low-Resolution Imaging Spectrometer"
     },
     {
-        "name": "Rayn03",
+        "publication": "Rayn03",
         "bibcode": "2003PASP..115..362R",
         "doi": "10.1086/367745",
         "description": "SpeX: A Medium-Resolution 0.8-5.5 Micron Spectrograph and Imager for the NASA Infrared Telescope Facility"
     },
     {
-        "name": "Houc04",
+        "publication": "Houc04",
         "bibcode": "2004SPIE.5487...62H",
         "doi": "10.1117/12.550517",
         "description": "The infrared spectrograph on the Spitzer Space Telescope"
     },
     {
-        "name": "Burg10a",
+        "publication": "Burg10a",
         "bibcode": "2010ApJ...710.1142B",
         "doi": "10.1088/0004-637X/710/2/1142",
         "description": "SpeX Spectroscopy of Unresolved Very Low Mass Binaries. I. Identification of 17 Candidate Binaries Straddling the L Dwarf/T Dwarf Transition"
     },
     {
-        "name": "Burg06a",
+        "publication": "Burg06a",
         "bibcode": "2006AJ....131.1007B",
         "doi": "10.1086/499042",
         "description": "Resolved Spectroscopy of M Dwarf/L Dwarf Binaries. I. DENIS J220002.05-303832.9AB"
     },
     {
-        "name": "Kirk06",
+        "publication": "Kirk06",
         "bibcode": "2006ApJ...639.1120K",
         "doi": "10.1086/499622",
         "description": "Discovery of a Very Young Field L Dwarf, 2MASS J01415823-4633574"
     },
     {
-        "name": "Burg06d",
+        "publication": "Burg06d",
         "bibcode": "2006ApJ...645.1485B",
         "doi": "10.1086/504375",
         "description": "Discovery of the Coolest Extreme Subdwarf"
     },
     {
-        "name": "Burg07c",
+        "publication": "Burg07c",
         "bibcode": "2007ApJ...658..617B",
         "doi": "10.1086/511176",
         "description": "The Physical Properties of HD 3651B: An Extrasolar Nemesis?"
     },
     {
-        "name": "Burg07d",
+        "publication": "Burg07d",
         "bibcode": "2007ApJ...659..655B",
         "doi": "10.1086/511027",
         "description": "Binaries and the L Dwarf/T Dwarf Transition"
     },
     {
-        "name": "Hook04",
+        "publication": "Hook04",
         "bibcode": "2004PASP..116..425H",
         "doi": "10.1086/383624",
         "description": "The Gemini-North Multi-Object Spectrograph: Performance in Imaging, Long-Slit, and Multi-Object Spectroscopic Modes"
     },
     {
-        "name": "Luhm06a",
+        "publication": "Luhm06a",
         "bibcode": "2009ApJ...691.1265L",
         "doi": "10.1088/0004-637X/691/2/1265",
         "description": "Discovery of a Wide Binary Brown Dwarf Born in Isolation"
     },
     {
-        "name": "Luhm09b",
+        "publication": "Luhm09b",
         "bibcode": "2009ApJ...703..399L",
         "doi": "10.1088/0004-637X/703/1/399",
         "description": "An Infrared/X-Ray Survey for New Members of the Taurus Star-Forming Region"
     },
     {
-        "name": "Gagn15a",
+        "publication": "Gagn15a",
         "bibcode": "2015ApJ...798...73G",
         "doi": "10.1088/0004-637X/798/2/73",
         "description": "BANYAN. V. A Systematic All-sky Survey for New Very Late-type Low-mass Stars and Brown Dwarfs in Nearby Young Moving Groups"
     },
     {
-        "name": "Burg14a",
+        "publication": "Burg14a",
         "bibcode": "2014ASInC..11....7B",
         "doi": null,
         "description": "The SpeX Prism Library: 1000+ low-resolution, near-infrared spectra of ultracool M, L, T and Y dwarfs"
     },
     {
-        "name": "Alli94",
+        "publication": "Alli94",
         "bibcode": "1994PASP..106..983A",
         "doi": "10.1086/133471",
         "description": "A Low-Dispersion Survey Spectrograph (LDSS-2) for the William Herschel Telescope"
     },
     {
-        "name": "Mars08b",
+        "publication": "Mars08b",
         "bibcode": "2008SPIE.7014E..54M",
         "doi": "10.1117/12.789972",
         "description": "The MagE spectrograph"
     },
     {
-        "name": "Burg04a",
+        "publication": "Burg04a",
         "bibcode": "2004ApJ...604..827B",
         "doi": "10.1086/382129",
         "description": "S Orionis 70: Just a Foreground Field Brown Dwarf?"
     },
     {
-        "name": "Burg04b",
+        "publication": "Burg04b",
         "bibcode": "2004AJ....127.2856B",
         "doi": "10.1086/383549",
         "description": "The 2MASS Wide-Field T Dwarf Search. III. Seven New T Dwarfs and Other Cool Dwarf Discoveries"
     },
     {
-        "name": "Burg04d",
+        "publication": "Burg04d",
         "bibcode": "2004ApJS..155..191B",
         "doi": "10.1086/424386",
         "description": "T Dwarfs and the Substellar Mass Function. I. Monte Carlo Simulations"
     },
     {
-        "name": "Burn11",
+        "publication": "Burn11",
         "bibcode": "2011MNRAS.414.3590B",
         "doi": "10.1111/j.1365-2966.2011.18664.x",
         "description": "The properties of the T8.5p dwarf Ross 458C"
     },
     {
-        "name": "Grif12",
+        "publication": "Grif12",
         "bibcode": "2012AJ....144..148G",
         "doi": "10.1088/0004-6256/144/5/148",
         "description": "Spitzer Photometry of WISE-selected Brown Dwarf and Hyper-luminous Infrared Galaxy Candidates"
     },
     {
-        "name": "Koba00",
+        "publication": "Koba00",
         "bibcode": "2000SPIE.4008.1056K",
         "doi": "10.1117/12.395423",
         "description": "IRCS: infrared camera and spectrograph for the Subaru Telescope"
     },
     {
-        "name": "Hoda03",
+        "publication": "Hoda03",
         "bibcode": "2003PASP..115.1388H",
         "doi": "10.1086/379669",
         "description": "The Gemini Near-Infrared Imager (NIRI)"
     },
     {
-        "name": "Mama05",
+        "publication": "Mama05",
         "bibcode": "2005ApJ...634.1385M",
         "doi": "10.1086/468181",
         "description": "A Moving Cluster Distance to the Exoplanet 2M1207b in the TW Hydrae Association"
     },
     {
-        "name": "Alle13",
+        "publication": "Alle13",
         "bibcode": "2013ApJ...772...79A",
         "doi": "10.1088/0004-637X/772/2/79",
         "description": "A Near-infrared Spectroscopic Study of Young Field Ultracool Dwarfs"
     },
     {
-        "name": "Mont01",
+        "publication": "Mont01",
         "bibcode": "2001MNRAS.328...45M",
         "doi": "10.1046/j.1365-8711.2001.04781.x",
         "description": "Late-type members of young stellar kinematic groups - I. Single stars"
     },
     {
-        "name": "Luri14",
+        "publication": "Luri14",
         "bibcode": "2014AJ....148...91L",
         "doi": "10.1088/0004-6256/148/5/91",
         "description": "The solar neighborhood. XXXIV. a search for planets orbiting nearby M dwarfs using astrometry"
     },
     {
-        "name": "Rice10a",
+        "publication": "Rice10a",
         "bibcode": "2010ApJS..186...63R",
         "doi": "10.1088/0067-0049/186/1/63",
         "description": "Physical Properties of Young Brown Dwarfs and Very Low Mass Stars Inferred from High-resolution Model Spectra"
     },
     {
-        "name": "Luhm13",
+        "publication": "Luhm13",
         "bibcode": "2013ApJ...767L...1L",
         "doi": "10.1088/2041-8205/767/1/L1",
         "description": "Discovery of a Binary Brown Dwarf at 2 pc from the Sun"
     },
     {
-        "name": "Kell15",
+        "publication": "Kell15",
         "bibcode": "2015AJ....150..182K",
         "doi": "10.1088/0004-6256/150/6/182",
         "description": "A Targeted Search for Peculiarly Red L and T Dwarfs in SDSS, 2MASS, and WISE: Discovery of a Possible L7 Member of the TW Hydrae Association"
     },
     {
-        "name": "GagnUnpub",
+        "publication": "GagnUnpub",
         "bibcode": null,
         "doi": null,
         "description": "Jonathan's unpublished data"
     },
     {
-        "name": "Hink08",
+        "publication": "Hink08",
         "bibcode": "2008SPIE.7015E..19H",
         "doi": "10.1117/12.789557",
         "description": "A new integral field spectrograph for exoplanetary science at Palomar"
     },
     {
-        "name": "Ditt14",
+        "publication": "Ditt14",
         "bibcode": "2014ApJ...784..156D",
         "doi": "10.1088/0004-637X/784/2/156",
         "description": "Trigonometric Parallaxes for 1507 Nearby Mid-to-late M Dwarfs"
     },
     {
-        "name": "Raja15",
+        "publication": "Raja15",
         "bibcode": "2015ApJ...809L..33R",
         "doi": "10.1088/2041-8205/809/2/L33",
         "description": "Characterizing the Atmospheres of the HR8799 Planets with HST/WFC3"
     },
     {
-        "name": "Oppe13",
+        "publication": "Oppe13",
         "bibcode": "2013ApJ...768...24O",
         "doi": "10.1088/0004-637X/768/1/24",
         "description": "Reconnaissance of the HR 8799 Exosolar System. I. Near-infrared Spectroscopy"
     },
     {
-        "name": "Schn16",
+        "publication": "Schn16",
         "bibcode": "2016ApJ...822L...1S",
         "doi": "10.3847/2041-8205/822/1/L1",
         "description": "WISEA J114724.10-204021.3: A Free-Floating Planetary Mass Member of the TW Hya Association"
     },
     {
-        "name": "McGr03",
+        "publication": "McGr03",
         "bibcode": "2003SPIE.4841.1581M",
         "doi": "10.1117/12.459448",
         "description": "Gemini near-infrared integral field spectrograph (NIFS)"
     },
     {
-        "name": "Eike04",
+        "publication": "Eike04",
         "bibcode": "2004SPIE.5492.1196E",
         "doi": "10.1117/12.549796",
         "description": "FLAMINGOS-2: the facility near-infrared wide-field imager and multi-object spectrograph for Gemini"
     },
     {
-        "name": "Kono16",
+        "publication": "Kono16",
         "bibcode": "2016ApJ...829L...4K",
         "doi": "10.3847/2041-8205/829/1/L4",
         "description": "Discovery of a Low-Mass Companion to the Nearby Debris Disk Host HR 2562"
     },
     {
-        "name": "Zurl16",
+        "publication": "Zurl16",
         "bibcode": "2016A&A...587A..57Z",
         "doi": "10.1051/0004-6361/201526835",
         "description": "First light of the VLT planet finder SPHERE. III. New spectrophotometry and astrometry of the HR 8799 exoplanetary system"
     },
     {
-        "name": "Ston16",
+        "publication": "Ston16",
         "bibcode": "2016ApJ...818L..12S",
         "doi": "10.3847/2041-8205/818/1/L12",
         "description": "Adaptive Optics imaging of VHS 1256-1257: A Low Mass Companion to a Brown Dwarf Binary System"
     },
     {
-        "name": "Eise03",
+        "publication": "Eise03",
         "bibcode": "2003SPIE.4841.1548E",
         "doi": "10.1117/12.459468",
         "description": "SINFONI - Integral field spectroscopy at 50 milli-arcsecond resolution with the ESO VLT"
     },
     {
-        "name": "Bonn04",
+        "publication": "Bonn04",
         "bibcode": "2004Msngr.117...17B",
         "doi": null,
         "description": "First light of SINFONI at the VLT"
     },
     {
-        "name": "Appe98",
+        "publication": "Appe98",
         "bibcode": "1998Msngr..94....1A",
         "doi": null,
         "description": "Successful commissioning of FORS1 - the first optical instrument on the VLT."
     },
     {
-        "name": "Wils04",
+        "publication": "Wils04",
         "bibcode": "2004SPIE.5492.1295W",
         "doi": "10.1117/12.550925",
         "description": "Mass producing an efficient NIR spectrograph (TripleSpec)"
     },
     {
-        "name": "Alli02",
+        "publication": "Alli02",
         "bibcode": "2002PASP..114..892A",
         "doi": "10.1086/341712",
         "description": "Integral Field Spectroscopy with the Gemini Multiobject Spectrograph. I. Design, Construction, and Testing"
     },
     {
-        "name": "Elia06",
+        "publication": "Elia06",
         "bibcode": "2006SPIE.6269E..4CE",
         "doi": "10.1117/12.671817",
         "description": "Design of the Gemini near-infrared spectrograph"
     },
     {
-        "name": "Kash00",
+        "publication": "Kash00",
         "bibcode": "2000SPIE.4008..104K",
         "doi": "10.1117/12.395414",
         "description": "FOCAS: faint object camera and spectrograph for the Subaru Telescope"
     },
     {
-        "name": "Simc08",
+        "publication": "Simc08",
         "bibcode": "2008SPIE.7014E..0US",
         "doi": "10.1117/12.790414",
         "description": "FIRE: a near-infrared cross-dispersed echellette spectrometer for the Magellan telescopes"
     },
     {
-        "name": "DePo93",
+        "publication": "DePo93",
         "bibcode": "1993SPIE.1946..667D",
         "doi": "10.1117/12.158725",
         "description": "Ohio State Infrared Imager/Spectrometer (OSIRIS)"
     },
     {
-        "name": "Lowr99",
+        "publication": "Lowr99",
         "bibcode": "1999ApJ...512L..69L",
         "doi": "10.1086/311858",
         "description": "A Candidate Substellar Companion to CD -33\u00b07795 (TWA 5)"
     },
     {
-        "name": "Naud14",
+        "publication": "Naud14",
         "bibcode": "2014ApJ...787....5N",
         "doi": "10.1088/0004-637X/787/1/5",
         "description": "Discovery of a Wide Planetary-mass Companion to the Young M3 Star GU Psc"
     },
     {
-        "name": "Saum07a",
+        "publication": "Saum07a",
         "bibcode": "2007ApJ...656.1136S",
         "doi": "10.1086/510557",
         "description": "Physical Parameters of Two Very Cool T Dwarfs"
     },
     {
-        "name": "Fili15",
+        "publication": "Fili15",
         "bibcode": "2015ApJ...810..158F",
         "doi": "10.1088/0004-637X/810/2/158",
         "description": "Fundamental Parameters and Spectral Energy Distributions of Young and Field Age Objects with Masses Spanning the Stellar to Planetary Regime"
     },
     {
-        "name": "Step09",
+        "publication": "Step09",
         "bibcode": "2009ApJ...702..154S",
         "doi": "10.1088/0004-637X/702/1/154",
         "description": "The 0.8-14.5 \u03bcm Spectra of Mid-L to Mid-T Dwarfs: Diagnostics of Effective Temperature, Grain Sedimentation, Gas Transport, and Surface Gravity"
     },
     {
-        "name": "Legg99",
+        "publication": "Legg99",
         "bibcode": "1999ApJ...517L.139L",
         "doi": "10.1086/312049",
         "description": "REVISED FLUXES FOR GLIESE 229B"
     },
     {
-        "name": "Schu98",
+        "publication": "Schu98",
         "bibcode": "1998ApJ...492L.181S",
         "doi": "10.1086/311103",
         "description": "First Results from the Space Telescope Imaging Spectrograph: Optical Spectra of Gliese 229B"
     },
     {
-        "name": "Matt94",
+        "publication": "Matt94",
         "bibcode": "1994ExA.....3...77M",
         "doi": "10.1007/BF00430121",
         "description": "The near infrared camera on the W.M. Keck telescope"
     },
     {
-        "name": "Noll97",
+        "publication": "Noll97",
         "bibcode": "1997ApJ...489L..87N",
         "doi": "10.1086/310954",
         "description": "Detection of Abundant Carbon Monoxide in the Brown Dwarf Gliese 229B"
     },
     {
-        "name": "Moun90",
+        "publication": "Moun90",
         "bibcode": "1990SPIE.1235...25M",
         "doi": null,
         "description": "An advanced cooled grating spectrometer for UKIRT"
     },
     {
-        "name": "Wood98",
+        "publication": "Wood98",
         "bibcode": "1998PASP..110.1183W",
         "doi": "10.1086/316243",
         "description": "The Space Telescope Imaging Spectrograph Design"
     },
     {
-        "name": "vanB61",
+        "publication": "vanB61",
         "bibcode": "1961AJ.....66..528V",
         "doi": "10.1086/108457",
         "description": "A search for stars of low luminosity"
     },
     {
-        "name": "Gicl59",
+        "publication": "Gicl59",
         "bibcode": "1959LowOB...4..136G",
         "doi": null,
         "description": "Lowell proper motions II : proper motion survey of the Northern Hemisphere with the 13-inch photographic telescope of the Lowell Observatory"
     },
     {
-        "name": "Rebo95",
+        "publication": "Rebo95",
         "bibcode": "1995Natur.377..129R ",
         "doi": "10.1038/377129a0",
         "description": "Discovery of a brown dwarf in the Pleiades star cluster"
     },
     {
-        "name": "Lieb79",
+        "publication": "Lieb79",
         "bibcode": "1979ApJ...233..226L",
         "doi": "10.1086/157384",
         "description": "New results from a survey of faint proper-motion stars: a probable deficiency of very low luminosity degenerates"
     },
     {
-        "name": "Prob83",
+        "publication": "Prob83",
         "bibcode": "1983ApJ...274..245P",
         "doi": "10.1086/161442",
         "description": "LHS 2924: A uniquely cool low-luminosity star with a peculiar energy distribution"
     },
     {
-        "name": "Turn03",
+        "publication": "Turn03",
         "bibcode": "2003ApJS..149..423T",
         "doi": "10.1086/379320",
         "description": "Target selection for SETI. II. Tycho-2 dwarfs, old open clusters, and the nearest 100 stars"
     },
     {
-        "name": "Reid87",
+        "publication": "Reid87",
         "bibcode": "1987MNRAS.225..873R",
         "doi": "10.1093/mnras/225.4.873",
         "description": "The stellar mass function at low luminosities"
     },
     {
-        "name": "Gicl61",
+        "publication": "Gicl61",
         "bibcode": "1961LowOB...5...61G ",
         "doi": null,
         "description": "Lowell proper motions III : proper motion survey of the Northern Hemisphere with the 13-inch photographic telescope of the Lowell Observatory"
     },
     {
-        "name": "Leib99",
+        "publication": "Leib99",
         "bibcode": "1999ApJ...519..345L",
         "doi": "10.1086/307349",
         "description": "A 2MASS Ultracool M Dwarf Observed in a Spectacular Flare"
     },
     {
-        "name": "Cruz04",
+        "publication": "Cruz04",
         "bibcode": "2004ApJ...604L..61C",
         "doi": "10.1086/383415",
         "description": "2MASS J05185995-2828372: Discovery of an Unresolved L/T Binary"
     },
     {
-        "name": "Bard14",
+        "publication": "Bard14",
         "bibcode": "2014ApJ...794..143B",
         "doi": "10.1088/0004-637X/794/2/143",
         "description": "SpeX Spectroscopy of Unresolved Very Low Mass Binaries. II. Identification of 14 Candidate Binaries with Late-M/Early-L and T Dwarf Components"
     },
     {
-        "name": "Burg03e",
+        "publication": "Burg03e",
         "bibcode": "2003AJ....126.2487B",
         "doi": "10.1086/378608",
         "description": "The 2MASS Wide-Field T Dwarf Search. II. Discovery of Three T Dwarfs in the Southern Hemisphere"
     },
     {
-        "name": "Beck88",
+        "publication": "Beck88",
         "bibcode": "1988Natur.336..656B",
         "doi": "10.1038/336656a0",
         "description": "A low-temperature companion to a white dwarf star (GD 165B Discovery)"
     },
     {
-        "name": "McEl06",
+        "publication": "McEl06",
         "bibcode": "2006AJ....132.2074M",
         "doi": "10.1086/508199",
         "description": "Resolved Spectroscopy of M Dwarf/L Dwarf Binaries. II. 2MASS J17072343-0558249AB"
     },
     {
-        "name": "Tinn05a",
+        "publication": "Tinn05a",
         "bibcode": "2005ApJ...623.1171T",
         "doi": "10.1086/428661",
         "description": "Three Low-Mass Planets from the Anglo-Australian Planet Search"
     },
     {
-        "name": "Tinn05b",
+        "publication": "Tinn05b",
         "bibcode": "2005AJ....130.2326T",
         "doi": "10.1086/491734",
         "description": "The 2MASS Wide-Field T Dwarf Search. IV. Hunting Out T Dwarfs with Methane Imaging"
     },
     {
-        "name": "Reid05",
+        "publication": "Reid05",
         "bibcode": "2005PASP..117..676R",
         "doi": "10.1086/430462",
         "description": "Probing the LHS Catalog. II. Faint Proper-Motion Stars"
     },
     {
-        "name": "Seif10",
+        "publication": "Seif10",
         "bibcode": "2010A&A...512A..37S",
         "doi": "10.1051/0004-6361/200913368",
         "description": "On the kinematic age of brown dwarfs: radial velocities and space motions of 43 nearby L dwarfs"
     },
     {
-        "name": "Naka95",
+        "publication": "Naka95",
         "bibcode": "1995Natur.378..463N",
         "doi": "10.1038/378463a0",
         "description": "Discovery of a cool brown dwarf"
     },
     {
-        "name": "Burg02a",
+        "publication": "Burg02a",
         "bibcode": "2002ApJ...564..421B",
         "doi": "10.1086/324033",
         "description": "The spectra of T dwarfs. I. Near-infrared data and spectral classification"
     },
     {
-        "name": "Mugr06",
+        "publication": "Mugr06",
         "bibcode": "2006MNRAS.373L..31M",
         "doi": "10.1111/j.1745-3933.2006.00237.x",
         "description": "HD 3651B: the first directly imaged brown dwarf companion of an exoplanet host star"
     },
     {
-        "name": "Burg99",
+        "publication": "Burg99",
         "bibcode": "1999ApJ...522L..65B",
         "doi": "10.1086/312221",
         "description": "Discovery of four field methane (T-type) dwarfs with the Two Micron All-Sky Survey"
     },
     {
-        "name": "Albe11",
+        "publication": "Albe11",
         "bibcode": "2011AJ....141..203A",
         "doi": "10.1088/0004-6256/141/6/203",
         "description": "37 new T-type brown dwarfs in the Canada-France Brown Dwarfs Survey"
     },
     {
-        "name": "Schn91",
+        "publication": "Schn91",
         "bibcode": "1991AJ....102.1180S",
         "doi": "10.1086/115945",
         "description": "Spectroscopy of an unusual emission line M star"
     },
     {
-        "name": "Burg00c",
+        "publication": "Burg00c",
         "bibcode": "2000AJ....120.1100B",
         "doi": "10.1086/301475",
         "description": "Discovery of a Bright Field Methane (T-Type) Brown Dwarf by 2MASS"
     },
     {
-        "name": "Burg02b",
+        "publication": "Burg02b",
         "bibcode": "2002AJ....123.2744B",
         "doi": "10.1086/339836",
         "description": "A Search for Variability in the Active T Dwarf 2MASS 1237+6526"
     },
     {
-        "name": "Burg02c",
+        "publication": "Burg02c",
         "bibcode": "2002ApJ...571L.151B",
         "doi": "10.1086/341343",
         "description": "Evidence of Cloud Disruption in the L/T Dwarf Transition"
     },
     {
-        "name": "Burg03a",
+        "publication": "Burg03a",
         "bibcode": "2003AJ....125..850B",
         "doi": "10.1086/345975",
         "description": "The 2Mass Wide-Field T Dwarf Search. I. Discovery of a Bright T Dwarf within 10 Parsecs of the Sun"
     },
     {
-        "name": "Burg05b",
+        "publication": "Burg05b",
         "bibcode": "2005ApJ...626..486B",
         "doi": "10.1086/429788",
         "description": "Quiescent Radio Emission from Southern Late-Type M Dwarfs and a Spectacular Radio Flare from the M8 Dwarf DENIS 1048-3956"
     },
     {
-        "name": "Burg09b",
+        "publication": "Burg09b",
         "bibcode": "2009AJ....137.4621B",
         "doi": "10.1088/0004-6256/137/6/4621",
         "description": "An Age Constraint for the Very Low Mass Stellar/Brown Dwarf Binary 2MASS J03202839-0446358AB"
     },
     {
-        "name": "Burg09c",
+        "publication": "Burg09c",
         "bibcode": "2009AJ....138.1563B",
         "doi": "10.1088/0004-6256/138/6/1563",
         "description": "Resolved Spectroscopy of M Dwarf/L Dwarf Binaries. III. The \"Wide\" L3.5/L4 Dwarf Binary 2Mass J15500845+1455180AB"
     },
     {
-        "name": "Burg11c",
+        "publication": "Burg11c",
         "bibcode": "2011ApJ...739...49B",
         "doi": "10.1088/0004-637X/739/1/49",
         "description": "The Hyperactive L Dwarf 2MASS J13153094-2649513: Continued Emission and a Brown Dwarf Companion"
     },
     {
-        "name": "Burg12a",
+        "publication": "Burg12a",
         "bibcode": "2012ApJ...745...26B",
         "doi": "10.1088/0004-637X/745/1/26",
         "description": "Resolved Spectroscopy of a Brown Dwarf Binary at the T Dwarf/Y Dwarf Transition"
     },
     {
-        "name": "Burg12b",
+        "publication": "Burg12b",
         "bibcode": "2012ApJ...757..110B",
         "doi": "10.1088/0004-637X/757/2/110",
         "description": "Discovery of a Very Low Mass Triple with Late-M and T Dwarf Components: LP 704-48/SDSS J0006-0852AB"
     },
     {
-        "name": "Burg13a",
+        "publication": "Burg13a",
         "bibcode": "2013ApJ...762L...3B",
         "doi": "10.1088/2041-8205/762/1/L3",
         "description": "Detection of Radio Emission from the Hyperactive L Dwarf 2MASS J13153094-2649513AB"
     },
     {
-        "name": "Burg13b",
+        "publication": "Burg13b",
         "bibcode": "2013ApJ...772..129B",
         "doi": "10.1088/0004-637X/772/2/129",
         "description": "Resolved Near-infrared Spectroscopy of WISE J104915.57-531906.1AB: A Flux-reversal Binary at the L dwarf/T Dwarf Transition"
     },
     {
-        "name": "Burg14b",
+        "publication": "Burg14b",
         "bibcode": "2014ApJ...785...48B",
         "doi": "10.1088/0004-637X/785/1/48",
         "description": "A Monitoring Campaign for Luhman 16AB. I. Detection of Resolved Near-infrared Spectroscopic Variability"
     },
     {
-        "name": "Burg15a",
+        "publication": "Burg15a",
         "bibcode": "2015AJ....149..104B",
         "doi": "10.1088/0004-6256/149/3/104",
         "description": "WISE J072003.20-084651.2: an Old and Active M9.5 + T5 Spectral Binary 6 pc from the Sun"
     },
     {
-        "name": "Bonn14a",
+        "publication": "Bonn14a",
         "bibcode": "2014A&A...562A.111B",
         "doi": "10.1051/0004-6361/201322119",
         "description": "Characterization of the gaseous companion \u03ba Andromedae b. New Keck and LBTI high-contrast observations"
     },
     {
-        "name": "Bonn14c",
+        "publication": "Bonn14c",
         "bibcode": "2014A&A...567L...9B",
         "doi": "10.1051/0004-6361/201424041",
         "description": "Physical and orbital properties of beta Pictoris b"
     },
     {
-        "name": "Zapa14b",
+        "publication": "Zapa14b",
         "bibcode": "2014A&A...568A..77Z",
         "doi": "10.1051/0004-6361/201423848",
         "description": "Search for free-floating planetary-mass objects in the Pleiades"
     },
     {
-        "name": "Zapa14c",
+        "publication": "Zapa14c",
         "bibcode": "2014A&A...572A..67Z",
         "doi": "10.1051/0004-6361/201424634",
         "description": "Spectroscopic follow-up of L- and T-type proper-motion member candidates in the Pleiades"
     },
     {
-        "name": "Toku05",
+        "publication": "Toku05",
         "bibcode": "2005PASP..117..421T",
         "doi": "10.1086/429382",
         "description": "The Mauna Kea Observatories Near-Infrared Filter Set. III. Isophotal Wavelengths and Absolute Calibration"
     },
     {
-        "name": "Biha10",
+        "publication": "Biha10",
         "bibcode": "2010A&A...519A..93B",
         "doi": "10.1051/0004-6361/200913676",
         "description": "Near-infrared low-resolution spectroscopy of Pleiades L-type brown dwarfs"
     },
     {
-        "name": "vanL09",
+        "publication": "vanL09",
         "bibcode": "2009A&A...497..209V",
         "doi": "10.1051/0004-6361/200811382",
         "description": "Parallaxes and proper motions for 20 open clusters as based on the new Hipparcos catalogue"
     },
     {
-        "name": "Aume09",
+        "publication": "Aume09",
         "bibcode": "2009MNRAS.397.1286A",
         "doi": "10.1111/j.1365-2966.2009.15053.x",
         "description": "Kinematics and history of the solar neighbourhood revisited"
     },
     {
-        "name": "Zapa97",
+        "publication": "Zapa97",
         "bibcode": "1997ApJ...491L..81Z",
         "doi": "10.1086/311073",
         "description": "New Brown Dwarfs in the Pleiades Cluster"
     },
     {
-        "name": "Bara98",
+        "publication": "Bara98",
         "bibcode": "1998A&A...337..403B",
         "doi": null,
         "description": "Evolutionary models for solar metallicity low-mass stars: mass-magnitude relationships and color-magnitude diagrams"
     },
     {
-        "name": "Malo13",
+        "publication": "Malo13",
         "bibcode": "2013ApJ...762...88M",
         "doi": "10.1088/0004-637X/762/2/88",
         "description": "Bayesian Analysis to Identify New Star Candidates in Nearby Young Stellar Kinematic Groups"
     },
     {
-        "name": "PID50367",
+        "publication": "PID50367",
         "bibcode": "",
         "doi": null,
         "description": "PIs M. Cushing and M. Liu"
     },
     {
-        "name": "Male14",
+        "publication": "Male14",
         "bibcode": "2014ApJ...786...32M",
         "doi": "10.1088/0004-637X/786/1/32",
         "description": "Magellan Adaptive Optics First-light Observations of the Exoplanet beta Pic B. I. Direct Imaging in the Far-red Optical with MagAO+VisAO and in the Near-ir with NICI"
     },
     {
-        "name": "PID2",
+        "publication": "PID2",
         "bibcode": null,
         "doi": null,
         "description": "PI J. Houck"
     },
     {
-        "name": "PID30540",
+        "publication": "PID30540",
         "bibcode": null,
         "doi": null,
         "description": "PI J. Houck"
     },
     {
-        "name": "PID50059",
+        "publication": "PID50059",
         "bibcode": null,
         "doi": null,
         "description": "PI A. Burgasser"
     },
     {
-        "name": "PID51",
+        "publication": "PID51",
         "bibcode": null,
         "doi": null,
         "description": "PI J. Houck"
     },
     {
-        "name": "Stau98",
+        "publication": "Stau98",
         "bibcode": "1998ApJ...504..805S",
         "doi": "10.1086/311379",
         "description": "Keck Spectra of Pleiades Brown Dwarf Candidates and a Precise Determination of the Lithium Depletion Edge in the Pleiades"
     },
     {
-        "name": "Fahe13",
+        "publication": "Fahe13",
         "bibcode": "2013AJ....145....2F",
         "doi": "10.1088/0004-6256/145/1/2",
         "description": "2MASS J035523.37+113343.7: A Young, Dusty, Nearby, Isolated Brown Dwarf Resembling a Giant Exoplanet"
     },
     {
-        "name": "Kirk12",
+        "publication": "Kirk12",
         "bibcode": "2012ApJ...753..156K",
         "doi": "10.1088/0004-637X/753/2/156",
         "description": "Further Defining Spectral Type \"Y\" and Exploring the Low-mass End of the Field Brown Dwarf Mass Function"
     },
     {
-        "name": "Mone03",
+        "publication": "Mone03",
         "bibcode": "2003AJ....125..984M",
         "doi": "10.1086/345888",
         "description": "The USNO-B Catalog"
     },
     {
-        "name": "Stauf89",
+        "publication": "Stauf89",
         "bibcode": "1989ApJ...344L..21S",
         "doi": "10.1086/185521",
         "description": "Possible Pleiades Members with M approximately equal to 0.07 M<SUB>sun</SUB> : Identification of Brown Dwarf Candidates of Known Age, Distance, and Metallicity"
     },
     {
-        "name": "Lepi02",
+        "publication": "Lepi02",
         "bibcode": "2002AJ....124.1190L",
         "doi": "10.1086/341783",
         "description": "New High Proper Motion Stars from the Digitized Sky Survey. I. Northern Stars with 0.5\" yr-1<\u03bc<2.0\" yr-1 at Low Galactic Latitudes"
     },
     {
-        "name": "DENIS",
+        "publication": "DENIS",
         "bibcode": "2005yCat.2263....0D",
         "doi": null,
         "description": "DENIS Database 3rd Release"
     },
     {
-        "name": "Land92",
+        "publication": "Land92",
         "bibcode": "1992AJ....104..340L",
         "doi": "10.1086/116242",
         "description": "UBVRI Photometric Standard Stars in the Magnitude Range 11.5 \u3008 V \u3008 16.0 Around the Celestial Equator"
     },
     {
-        "name": "Land09",
+        "publication": "Land09",
         "bibcode": "2009AJ....137.4186L",
         "doi": "10.1088/0004-6256/137/5/4186",
         "description": "UBVRI Photometric Standard Stars Around the Celestial Equator: Updates and Additions"
     },
     {
-        "name": "McLe86",
+        "publication": "McLe86",
         "bibcode": "1986SPIE..627..430M",
         "doi": "10.1117/12.968120",
         "description": "System design of a 1-5 \u03bcm IR camera for astronomy"
     },
     {
-        "name": "Kono13",
+        "publication": "Kono13",
         "bibcode": "2013Sci...339.1398K",
         "doi": "10.1126/science.1232003",
         "description": "Detection of Carbon Monoxide and Water Absorption Lines in an Exoplanet Atmosphere"
     },
     {
-        "name": "Roel04",
+        "publication": "Roel04",
         "bibcode": "2004ApJS..154..418R",
         "doi": "10.1086/421978",
         "description": "Spitzer Infrared Spectrograph (IRS) Observations of M, L, and T Dwarfs"
     },
     {
-        "name": "Morr08",
+        "publication": "Morr08",
         "bibcode": "2008ApJ...676L.143M",
         "doi": "10.1086/587462",
         "description": "Observations of Disks around Brown Dwarfs in the TW Hydra Association with the Spitzer Infrared Spectrograph"
     },
     {
-        "name": "Riaz08",
+        "publication": "Riaz08",
         "bibcode": "2008ApJ...681.1584R",
         "doi": "10.1086/587547",
         "description": "New Brown Dwarf Disks in the TW Hydrae Association"
     },
     {
-        "name": "Riaz09b",
+        "publication": "Riaz09b",
         "bibcode": "2009ApJ...701..571R",
         "doi": "10.1088/0004-637X/705/2/1173",
         "description": "Brown Dwarf Disks at Ages of 5-10 Myr"
     },
     {
-        "name": "Riaz09c",
+        "publication": "Riaz09c",
         "bibcode": "2009ApJ...705.1173R",
         "doi": "10.1088/0004-637X/701/1/571",
         "description": "Silicate Evolution in Brown Dwarf Disks"
     },
     {
-        "name": "Hink15",
+        "publication": "Hink15",
         "bibcode": "2015ApJ...805L..10H",
         "doi": "10.1088/2041-8205/805/1/L10",
         "description": "Early Results from VLT SPHERE: Long-slit Spectroscopy of 2MASS 0122-2439 B, a Young Companion Near the Deuterium Burning Limit"
     },
     {
-        "name": "Bowl13",
+        "publication": "Bowl13",
         "bibcode": "2013ApJ...774...55B",
         "doi": "10.1088/0004-637X/774/1/55",
         "description": "Planets around Low-mass Stars. III. A Young Dusty L Dwarf Companion at the Deuterium-burning Limit"
     },
     {
-        "name": "Beuz08",
+        "publication": "Beuz08",
         "bibcode": "2008SPIE.7014E..18B",
         "doi": "10.1117/12.790120",
         "description": "SPHERE: a 'Planet Finder' instrument for the VLT"
     },
     {
-        "name": "PID3136",
+        "publication": "PID3136",
         "bibcode": null,
         "doi": null,
         "description": "PI K. Cruz"
     },
     {
-        "name": "Beic14",
+        "publication": "Beic14",
         "bibcode": "2014ApJ...783...68B",
         "doi": "10.1088/0004-637X/783/2/68",
         "description": "WISE Y Dwarfs as Probes of the Brown Dwarf-Exoplanet Connection"
     },
     {
-        "name": "Legg13",
+        "publication": "Legg13",
         "bibcode": "2013ApJ...763..130L",
         "doi": "10.1088/0004-637X/763/2/130",
         "description": "A Comparison of Near-infrared Photometry and Spectra for Y Dwarfs with a New Generation of Cool Cloudy Models"
     },
     {
-        "name": "Morl12",
+        "publication": "Morl12",
         "bibcode": "2012ApJ...756..172M",
         "doi": "10.1088/0004-637X/756/2/172",
         "description": "Neglected Clouds in T and Y Dwarf Atmospheres"
     },
     {
-        "name": "Schn15",
+        "publication": "Schn15",
         "bibcode": "2015ApJ...804...92S",
         "doi": "10.1088/0004-637X/804/2/92",
         "description": "Hubble Space Telescope Spectroscopy of Brown Dwarfs Discovered with the Wide-field Infrared Survey Explorer"
     },
     {
-        "name": "Gauz15",
+        "publication": "Gauz15",
         "bibcode": "2015ApJ...804...96G",
         "doi": "10.1088/0004-637X/804/2/96",
         "description": "Discovery of a Young Planetary Mass Companion to the Nearby M Dwarf VHS J125601.92-125723.9"
     },
     {
-        "name": "Arti15",
+        "publication": "Arti15",
         "bibcode": "2015ApJ...806..254A",
         "doi": "10.1088/0004-637X/806/2/254",
         "description": "BANYAN. VI. Discovery of a Companion at the Brown Dwarf/Planet-Mass Limit to a Tucana-Horologium M Dwarf"
     },
     {
-        "name": "Tinn14",
+        "publication": "Tinn14",
         "bibcode": "2014ApJ...796...39T",
         "doi": "10.1088/0004-637X/796/1/39",
         "description": "The Luminosities of the Coldest Brown Dwarfs"
     },
     {
-        "name": "Mars13",
+        "publication": "Mars13",
         "bibcode": "2013ApJ...762..119M",
         "doi": "10.1088/0004-637X/762/2/119",
         "description": "Parallaxes and Proper Motions of Ultracool Brown Dwarfs of Spectral Types Y and Late T"
     },
     {
-        "name": "Wils03a",
+        "publication": "Wils03a",
         "bibcode": "2003SPIE.4841..451W",
         "doi": "10.1117/12.460336",
         "description": "A Wide-Field Infrared Camera for the Palomar 200-inch Telescope"
     },
     {
-        "name": "Wahh11",
+        "publication": "Wahh11",
         "bibcode": "2011ApJ...729..139W",
         "doi": "10.1088/0004-637X/729/2/139",
         "description": "THE GEMINI NICI PLANET-FINDING CAMPAIGN: DISCOVERY OF A SUBSTELLAR L DWARF COMPANION TO THE NEARBY YOUNG M DWARF CD\u201335 2722"
     },
     {
-        "name": "Ftac03",
+        "publication": "Ftac03",
         "bibcode": "2003IAUS..211..521F",
         "doi": null,
         "description": "Searching for Ultracool Companions with NICI"
     },
     {
-        "name": "Tinn12",
+        "publication": "Tinn12",
         "bibcode": "2012ApJ...759...60T",
         "doi": "10.1088/0004-637X/759/1/60",
         "description": "WISE J163940.83-684738.6: A Y Dwarf Identified by Methane Imaging"
     },
     {
-        "name": "Mart04",
+        "publication": "Mart04",
         "bibcode": "2004SPIE.5492.1653M",
         "doi": "10.1117/12.551828",
         "description": "PANIC: a near-infrared camera for the Magellan telescopes"
     },
     {
-        "name": "Kirk13",
+        "publication": "Kirk13",
         "bibcode": "2013ApJ...776..128K",
         "doi": "10.1088/0004-637X/776/2/128",
         "description": "Discovery of the Y1 Dwarf WISE J064723.23-623235.5"
     },
     {
-        "name": "Rams04",
+        "publication": "Rams04",
         "bibcode": "2004SPIE.5492.1160R",
         "doi": "10.1117/12.551673",
         "description": "The commissioning of and first results from the UIST imager spectrometer"
     },
     {
-        "name": "Reyl10",
+        "publication": "Reyl10",
         "bibcode": "2010A&A...522A.112R",
         "doi": "10.1051/0004-6361/200913234",
         "description": "The ultracool-field dwarf luminosity-function and space density from the Canada-France Brown Dwarf Survey"
     },
     {
-        "name": "Roch03",
+        "publication": "Roch03",
         "bibcode": "2003SPIE.4841..901R",
         "doi": "10.1117/12.460987",
         "description": "UFTI: the 0.8 - 2.5 \u03bcm fast track imager for the UK infrared telescope"
     },
     {
-        "name": "Luhm14b",
+        "publication": "Luhm14b",
         "bibcode": "2014ApJ...786L..18L",
         "doi": "10.1088/2041-8205/786/2/L18",
         "description": "Discovery of a ~250 K Brown Dwarf at 2 pc from the Sun"
     },
     {
-        "name": "PID3431",
+        "publication": "PID3431",
         "bibcode": null,
         "doi": "",
         "description": "PI S. Leggett"
     },
     {
-        "name": "Dupu15a",
+        "publication": "Dupu15a",
         "bibcode": "2015ApJ...803..102D",
         "doi": "10.1088/0004-637X/803/2/102",
         "description": "Discovery of a Low-luminosity, Tight Substellar Binary at the T/Y Transition"
     },
     {
-        "name": "Dupu15b",
+        "publication": "Dupu15b",
         "bibcode": "2015ApJ...805...56D",
         "doi": "10.1088/0004-637X/805/1/56",
         "description": "The Mass\u2500Luminosity Relation in the L/T Transition: Individual Dynamical Masses for the New J-band Flux Reversal Binary SDSSJ105213.51+442255.7AB"
     },
     {
-        "name": "Geli11a",
+        "publication": "Geli11a",
         "bibcode": "2011AJ....142...57G",
         "doi": "10.1088/0004-6256/142/2/57",
         "description": "WISE Brown Dwarf Binaries: The Discovery of a T5+T5 and a T8.5+T9 System"
     },
     {
-        "name": "Geli11b",
+        "publication": "Geli11b",
         "bibcode": "2011ASPC..448..871G",
         "doi": null,
         "description": "Keck LGS-AO Imaging of Cool WISE Brown Dwarfs"
     },
     {
-        "name": "Dupu14",
+        "publication": "Dupu14",
         "bibcode": "2014ApJ...790..133D",
         "doi": "10.1088/0004-637X/790/2/133",
         "description": "New Evidence for a Substellar Luminosity Problem: Dynamical Mass for the Brown Dwarf Binary Gl 417BC"
     },
     {
-        "name": "Dupu11",
+        "publication": "Dupu11",
         "bibcode": "2011ApJ...733..122D",
         "doi": "10.1088/0004-637X/733/2/122",
         "description": "On the Distribution of Orbital Eccentricities for Very Low-mass Binaries"
     },
     {
-        "name": "Barm15",
+        "publication": "Barm15",
         "bibcode": "2015ApJ...804...61B",
         "doi": "10.1088/0004-637X/804/1/61",
         "description": "Simultaneous Detection of Water, Methane, and Carbon Monoxide in the Atmosphere of Exoplanet HR8799b"
     },
     {
-        "name": "Barm11a",
+        "publication": "Barm11a",
         "bibcode": "2011ApJ...733...65B",
         "doi": "10.1088/0004-637X/733/1/65",
         "description": "Clouds and Chemistry in the Atmosphere of Extrasolar Planet HR8799b"
     },
     {
-        "name": "Barm11b",
+        "publication": "Barm11b",
         "bibcode": "2011ApJ...735L..39B",
         "doi": "10.1088/2041-8205/735/2/L39",
         "description": "The Young Planet-mass Object 2M1207b: A Cool, Cloudy, and Methane-poor Atmosphere"
     },
     {
-        "name": "PID29",
+        "publication": "PID29",
         "bibcode": null,
         "doi": null,
         "description": "PI J. Houck"
     },
     {
-        "name": "PID20409",
+        "publication": "PID20409",
         "bibcode": null,
         "doi": null,
         "description": "PI M. Cushing"
     },
     {
-        "name": "PID20544",
+        "publication": "PID20544",
         "bibcode": null,
         "doi": null,
         "description": "PI A. Burgasser"
     },
     {
-        "name": "GagnSubm",
+        "publication": "GagnSubm",
         "bibcode": null,
         "doi": null,
         "description": null
     },
     {
-        "name": "Bern03",
+        "publication": "Bern03",
         "bibcode": "2003SPIE.4841.1694B",
         "doi": "10.1117/12.461502",
         "description": "MIKE: A Double Echelle Spectrograph for the Magellan Telescopes at Las Campanas Observatory"
     },
     {
-        "name": "Curr13a",
+        "publication": "Curr13a",
         "bibcode": "2013ApJ...776...15C",
         "doi": "10.1088/0004-637X/776/1/15",
         "description": "A Combined Very Large Telescope and Gemini Study of the Atmosphere of the Directly Imaged Planet, beta Pictoris b"
     },
     {
-        "name": "Rous03",
+        "publication": "Rous03",
         "bibcode": "2003SPIE.4839..140R",
         "doi": "10.1117/12.459332",
         "description": "NAOS, the first AO system of the VLT: on-sky performance"
     },
     {
-        "name": "Bonn13a",
+        "publication": "Bonn13a",
         "bibcode": "2013A&A...555A.107B",
         "doi": "10.1051/0004-6361/201220838",
         "description": "The near-infrared spectral energy distribution of beta Pictoris b"
     },
     {
-        "name": "Gagn15c",
+        "publication": "Gagn15c",
         "bibcode": "2015ApJ...808L..20G",
         "doi": "10.1088/2041-8205/808/1/L20",
         "description": "SDSS J111010.01+011613.1: A New Planetary-Mass T Dwarf Member of the AB Doradus Moving Group"
     },
     {
-        "name": "Tinn92",
+        "publication": "Tinn92",
         "bibcode": "1992ApJ...396..173T",
         "doi": "10.1086/171707",
         "description": "The Faintest Stars"
     },
     {
-        "name": "Hawk88",
+        "publication": "Hawk88",
         "bibcode": "1988MNRAS.234..177H",
         "doi": "10.1093/mnras/234.2.177",
         "description": "The luminosity function for low mass stars."
     },
     {
-        "name": "Beic13",
+        "publication": "Beic13",
         "bibcode": "2013ApJ...764..101B",
         "doi": "10.1088/0004-637X/764/1/101",
         "description": "The Coldest Brown Dwarf (or Free-floating Planet)?: The Y Dwarf WISE 1828+2650"
     },
     {
-        "name": "Bara15",
+        "publication": "Bara15",
         "bibcode": "2015A&A...577A..42B",
         "doi": "10.1051/0004-6361/201425481",
         "description": "New evolutionary models for pre-main sequence and main sequence low-mass stars down to the hydrogen-burning limit"
     },
     {
-        "name": "DayJ13",
+        "publication": "DayJ13",
         "bibcode": "2013MNRAS.430.1171D",
         "doi": "10.1093/mnras/sts685",
         "description": "The sub-stellar birth rate from UKIDSS"
     },
     {
-        "name": "Cush14",
+        "publication": "Cush14",
         "bibcode": "2014AJ....147..113C",
         "doi": "10.1088/0004-6256/147/5/113",
         "description": "Three New Cool Brown Dwarfs Discovered with the Wide-field Infrared Survey Explorer (WISE) and an Improved Spectrum of the Y0 Dwarf WISE J041022.71+150248.4"
     },
     {
-        "name": "Legg15",
+        "publication": "Legg15",
         "bibcode": "2015ApJ...799...37L",
         "doi": "10.1088/0004-637X/799/1/37",
         "description": "Near-infrared Photometry of Y Dwarfs: Low Ammonia Abundance and the Onset of Water Clouds"
     },
     {
-        "name": "Gagn15b",
+        "publication": "Gagn15b",
         "bibcode": "2015ApJS..219...33G",
         "doi": "10.1088/0067-0049/219/2/33",
         "description": "BANYAN. VII. A New Population of Young Substellar Candidate Members of Nearby Moving Groups from the BASS Survey"
     },
     {
-        "name": "Luhm14d",
+        "publication": "Luhm14d",
         "bibcode": "2014ApJ...794...16L",
         "doi": "10.1088/0004-637X/794/1/16",
         "description": "Near-infrared Detection of WD 0806-661 B with the Hubble Space Telescope"
     },
     {
-        "name": "StepPrep",
+        "publication": "StepPrep",
         "bibcode": null,
         "doi": null,
         "description": null
     },
     {
-        "name": "PID40076",
+        "publication": "PID40076",
         "bibcode": null,
         "doi": null,
         "description": "PI A. Mainzer"
     },
     {
-        "name": "PID40449",
+        "publication": "PID40449",
         "bibcode": null,
         "doi": null,
         "description": "PI S. Leggett"
     },
     {
-        "name": "PID20514",
+        "publication": "PID20514",
         "bibcode": null,
         "doi": null,
         "description": "PI D. Golimowski"
     },
     {
-        "name": "PID527",
+        "publication": "PID527",
         "bibcode": null,
         "doi": null,
         "description": "PI B. Burningham"
     },
     {
-        "name": "PID251",
+        "publication": "PID251",
         "bibcode": null,
         "doi": null,
         "description": "PI A. Burgasser"
     },
     {
-        "name": "PID3259",
+        "publication": "PID3259",
         "bibcode": null,
         "doi": null,
         "description": "PI A. Burgasser"
     },
     {
-        "name": "Deac12",
+        "publication": "Deac12",
         "bibcode": "2012ApJ...757..100D\n",
         "doi": "10.1088/0004-637X/757/1/100",
         "description": "LHS 2803B: A very wide mid-T dwarf companion to an old M dwarf identified from Pan-STARRS1"
     },
     {
-        "name": "Best15",
+        "publication": "Best15",
         "bibcode": "2015ApJ...814..118B",
         "doi": "10.1088/0004-637X/814/2/118",
         "description": "A Search for L/T Transition Dwarfs with Pan-STARRS1 and WISE. II. L/T Transition Atmospheres and Young Discoveries"
     },
     {
-        "name": "Cruz18",
+        "publication": "Cruz18",
         "bibcode": "2018AJ....155...34C",
         "doi": "10.3847/1538-3881/aa9d8a",
         "description": "Meeting the Cool Neighbors XII: An Optically-Anchored Analysis of the Near-Infrared Spectra of L Dwarfs."
     },
     {
-        "name": "Jame08",
+        "publication": "Jame08",
         "bibcode": "2008MNRAS.384.1399J",
         "doi": "10.1111/j.1365-2966.2007.12637.x",
         "description": "Proper motions of field L and T dwarfs"
     },
     {
-        "name": "Hamb01",
+        "publication": "Hamb01",
         "bibcode": "2001MNRAS.326.1315H",
         "doi": "10.1111/j.1365-2966.2001.04662.x",
         "description": "The SuperCOSMOS Sky Survey - III. Astrometry"
     },
     {
-        "name": "Burg15b",
+        "publication": "Burg15b",
         "bibcode": "2015ApJS..220...18B",
         "doi": "10.1088/0067-0049/220/1/18",
         "description": "The Brown Dwarf Kinematics Project (BDKP). IV. Radial Velocities"
     },
     {
-        "name": "Blak10",
+        "publication": "Blak10",
         "bibcode": "2010ApJ...723..684B",
         "doi": "10.1088/0004-637X/723/1/684",
         "description": "The NIRSPEC Ultracool Dwarf Radial Velocity Survey"
     },
     {
-        "name": "Geli10",
+        "publication": "Geli10",
         "bibcode": "2010AJ....140..110G",
         "doi": "10.1088/0004-6256/140/1/110",
         "description": "2MASS J20261584-2943124: an Unresolved L0.5 + T6 Spectral Binary"
     },
     {
-        "name": "FaheUnpub",
+        "publication": "FaheUnpub",
         "bibcode": null,
         "doi": null,
         "description": "unpublished data"
     },
     {
-        "name": "Lodi07b",
+        "publication": "Lodi07b",
         "bibcode": "2007MNRAS.374..372L",
         "doi": "10.1111/j.1365-2966.2006.11151.x",
         "description": "New brown dwarfs in Upper Sco using UKIDSS Galactic Cluster Survey science verification data"
     },
     {
-        "name": "Fahe16",
+        "publication": "Fahe16",
         "bibcode": "2016ApJS..225...10F",
         "doi": "10.3847/0067-0049/225/1/10",
         "description": "Population Properties of Brown Dwarf Analogs to Exoplanets"
     },
     {
-        "name": "Missing",
+        "publication": "Missing",
         "bibcode": null,
         "doi": null,
         "description": "Placeholder for missing publications"
     },
     {
-        "name": "Lawr12",
+        "publication": "Lawr12",
         "bibcode": "2012yCat.2314....0L",
         "doi": "10.1111/j.1365-2966.2007.12040.x",
         "description": "VizieR Online Data Catalog: UKIDSS-DR8 LAS, GCS and DXS Surveys (Lawrence+ 2012)"
     },
     {
-        "name": "BurgUnpub",
+        "publication": "BurgUnpub",
         "bibcode": null,
         "doi": null,
         "description": "unpublished data"
     },
     {
-        "name": "Lodi15",
+        "publication": "Lodi15",
         "bibcode": "2015A&A...579A..58L",
         "doi": "10.1051/0004-6361/201425551",
         "description": "A search for lithium in metal-poor L dwarfs"
     },
     {
-        "name": "Kore16",
+        "publication": "Kore16",
         "bibcode": "2016AJ....151...57K",
         "doi": "10.3847/0004-6256/151/3/57",
         "description": "The Low-mass Astrometric Binary LSR 1610-0040"
     },
     {
-        "name": "Rajp16",
+        "publication": "Rajp16",
         "bibcode": "2016A&A...596A..33R",
         "doi": "10.1051/0004-6361/201526776",
         "description": "Spectral energy distribution of M-subdwarfs: A study of their atmospheric properties"
     },
     {
-        "name": "Cush06a",
+        "publication": "Cush06a",
         "bibcode": "2006AJ....131.1797C",
         "doi": "10.1086/499583",
         "description": "The Schizophrenic Spectrum of LSR 1610-0040: A Peculiar M Dwarf/Subdwarf"
     },
     {
-        "name": "Buzz84",
+        "publication": "Buzz84",
         "bibcode": "1984Msngr..38....9B",
         "doi": null,
         "description": "The ESO Faint Object Spectrograph and Camera (EFOSC)"
     },
     {
-        "name": "Dekk86",
+        "publication": "Dekk86",
         "bibcode": "1986SPIE..627..339D",
         "doi": "10.1117/12.968108",
         "description": "ESOs Multimode Instrument for the Nasmyth focus of the 3.5 M New Technology Telescope"
     },
     {
-        "name": "Kirk14",
+        "publication": "Kirk14",
         "bibcode": "2014ApJ...783..122K",
         "doi": "10.1088/0004-637X/783/2/122",
         "description": "The AllWISE Motion Survey and the Quest for Cold Subdwarfs"
     },
     {
-        "name": "Cepa00",
+        "publication": "Cepa00",
         "bibcode": "2000SPIE.4008..623C",
         "doi": "10.1117/12.395520",
         "description": "OSIRIS tunable imager and spectrograph"
     },
     {
-        "name": "Wein16",
+        "publication": "Wein16",
         "bibcode": "2016AJ....152...24W",
         "doi": "10.3847/0004-6256/152/1/24",
         "description": "Trigonometric Parallaxes and Proper Motions of 134 Southern Late M, L, and T Dwarfs from the Carnegie Astrometric Planet Search Program"
     },
     {
-        "name": "Tann12",
+        "publication": "Tann12",
         "bibcode": "2012ApJS..203...10T",
         "doi": "10.1088/0067-0049/203/1/10",
         "description": "Keck NIRSPEC Radial Velocity Observations of Late-M Dwarfs"
     },
     {
-        "name": "Kirk16",
+        "publication": "Kirk16",
         "bibcode": "2016ApJS..224...36K",
         "doi": "10.3847/0067-0049/224/2/36",
         "description": "The AllWISE Motion Survey, Part 2"
     },
     {
-        "name": "Bric02",
+        "publication": "Bric02",
         "bibcode": "2002ApJ...580..317B",
         "doi": "10.1086/343127",
         "description": "The Initial Mass Function in the Taurus Star-forming Region"
     },
     {
-        "name": "Bric98",
+        "publication": "Bric98",
         "bibcode": "1998AJ....115.2074B",
         "doi": "10.1086/300338",
         "description": "A Search for Very Low Mass Pre-Main-Sequence Stars in Taurus"
     },
     {
-        "name": "Dahn17",
+        "publication": "Dahn17",
         "bibcode": "2017AJ....154..147D",
         "doi": "10.3847/1538-3881/aa880b",
         "description": "CCD Parallaxes for 309 Late-type Dwarfs and Subdwarfs"
     },
     {
-        "name": "LoopUnpub",
+        "publication": "LoopUnpub",
         "bibcode": null,
         "doi": null,
         "description": "Dagny's unpublished data"
     },
     {
-        "name": "Phan01",
+        "publication": "Phan01",
         "bibcode": "2001A&A...380..590P",
         "doi": "10.1051/0004-6361:20011461",
         "description": "\nNew neighbours: IV. 30 DENIS late-M dwarfs between 15 and 30 parsecs"
     },
     {
-        "name": "Agan16",
+        "publication": "Agan16",
         "bibcode": "2016AJ....151...46A",
         "doi": "10.3847/0004-6256/151/2/46",
         "description": "Characterization of the Very-low-mass Secondary in the GJ 660.1AB System"
     },
     {
-        "name": "Koen10",
+        "publication": "Koen10",
         "bibcode": "2010MNRAS.403.1949K",
         "doi": "10.1111/j.1365-2966.2009.16182.x",
         "description": "UBV(RI)C JHK observations of Hipparcos-selected nearby stars"
     },
     {
-        "name": "vanG18",
+        "publication": "vanG18",
         "bibcode": "2018ApJ...853...30V",
         "doi": "10.3847/1538-4357/aaa023",
         "description": "Stellar Parameters for Trappist-1"
     },
     {
-        "name": "GaiaDR1",
+        "publication": "GaiaDR1",
         "bibcode": "2016A&A...595A...2G",
         "doi": "10.1051/0004-6361/201629512",
         "description": "Gaia Data Release 1. Summary of the astrometric, photometric, and survey properties"
     },
     {
-        "name": "Schn11",
+        "publication": "Schn11",
         "bibcode": "2011ApJ...743..109S",
         "doi": "10.1088/0004-637X/743/2/109",
         "description": "Hunting the Coolest Dwarfs: Methods and Early Results"
     },
     {
-        "name": "Cham16",
+        "publication": "Cham16",
         "bibcode": "2016arXiv161205560C",
         "doi": null,
         "description": "The Pan-STARRS1 Surveys"
     },
     {
-        "name": "Fabr98",
+        "publication": "Fabr98",
         "bibcode": "1998PASP..110...79F",
         "doi": "10.1086/316111",
         "description": "The FAST Spectrograph for the Tillinghast Telescope"
     },
     {
-        "name": "Zhan17a",
+        "publication": "Zhan17a",
         "bibcode": "2017MNRAS.464.3040Z",
         "doi": "10.1093/mnras/stw2438",
         "description": "Primeval very low-mass stars and brown dwarfs - I. Six new L subdwarfs, classification and atmospheric properties"
     },
     {
-        "name": "Alam15",
+        "publication": "Alam15",
         "bibcode": "2015ApJS..219...12A",
         "doi": "10.1088/0067-0049/219/1/12",
         "description": "The Eleventh and Twelfth Data Releases of the Sloan Digital Sky Survey: Final Data from SDSS-III"
     },
     {
-        "name": "Phan06",
+        "publication": "Phan06",
         "bibcode": "2006A&A...446..515P",
         "doi": "10.1051/0004-6361:20054064",
         "description": "Spectroscopic distances of nearby ultracool dwarfs"
     },
     {
-        "name": "Schl12",
+        "publication": "Schl12",
         "bibcode": "2012AJ....143...80S",
         "doi": "10.1088/0004-637X/804/2/92",
         "description": "Cool young stars in the northern hemisphere: {beta} Pictoris and AB Doradus moving group candidates."
     },
     {
-        "name": "BDNYC",
+        "publication": "BDNYC",
         "bibcode": null,
         "doi": "10.5281/zenodo.45169",
         "description": "BDNYC Database on Zenodo"
     },
     {
-        "name": "Schm10.1045",
+        "publication": "Schm10.1045",
         "bibcode": "2010AJ....139.1045S",
         "doi": "10.1088/0004-6256/139/3/1045",
         "description": "Discovery of an Unusually Blue L Dwarf Within 10 pc of the Sun"
     },
     {
-        "name": "Gonz18",
+        "publication": "Gonz18",
         "bibcode": "2018ApJ...864..100G",
         "doi": "10.3847/1538-4357/aad3c7",
         "description": "Understanding Fundamental Properties and Atmospheric Features of Subdwarfs via a Case Study of SDSS J125637.13-022452.4"
     },
     {
-        "name": "Gill16",
+        "publication": "Gill16",
         "bibcode": "2016Natur.533..221G",
         "doi": "10.1038/nature17448",
         "description": "Temperate Earth-sized planets transiting a nearby ultracool dwarf star"
     },
     {
-        "name": "Best18",
+        "publication": "Best18",
         "bibcode": "2018ApJS..234....1B",
         "doi": "10.3847/1538-4365/aa9982",
         "description": "Photometry and Proper Motions of M, L, and T Dwarfs from the Pan-STARRS1 3pi Survey"
     },
     {
-        "name": "Cush10",
+        "publication": "Cush10",
         "bibcode": "2010AJ....140.1428C",
         "doi": "10.1088/0004-6256/140/5/1428",
         "description": "SDSS J141624.08+134826.7: Blue L dwarfs and Non-equilibrium Chemistry"
     },
     {
-        "name": "Teeg03",
+        "publication": "Teeg03",
         "bibcode": "2003ApJ...589L..51T",
         "doi": "10.1086/375803",
         "description": "Discovery of a New Nearby Star"
     },
     {
-        "name": "Pinf14",
+        "publication": "Pinf14",
         "bibcode": "2014MNRAS.444.1931P",
         "doi": "10.1093/mnras/stu1540",
         "description": "Discovery of a new Y dwarf: WISE J030449.03-270508.3"
     },
     {
-        "name": "Mart18",
+        "publication": "Mart18",
         "bibcode": "2018ApJ...867..109M",
         "doi": null,
         "description": null
     },
     {
-        "name": "Kirk19",
+        "publication": "Kirk19",
         "bibcode": "2019ApJS..240...19K",
         "doi": "10.3847/1538-4365/aaf6af",
         "description": "Preliminary Trigonometric Parallaxes of 184 Late-T and Y Dwarfs and an Analysis of the Field Substellar Mass Function into the Planetary Mass Regime"
     },
     {
-        "name": "Tinn18",
+        "publication": "Tinn18",
         "bibcode": "2018ApJS..236...28T",
         "doi": "10.3847/1538-4365/aabad3",
         "description": "New Y and T Dwarfs from WISE Identified by Methane Imaging"
     },
     {
-        "name": "Manj19",
+        "publication": "Manj19",
         "bibcode": "2019AJ....157..101M",
         "doi": "10.3847/1538-3881/aaf88f",
         "description": "Cloud Atlas: HST nir spectral library"
     },
     {
-        "name": "Sahl16",
+        "publication": "Sahl16",
         "bibcode": "2016MNRAS.455..357S",
         "doi": null,
         "description": null
     },
     {
-        "name": "Liu16",
+        "publication": "Liu16",
         "bibcode": "J/ApJ/833/96",
         "doi": null,
         "description": null
     },
     {
-        "name": "Wang18",
+        "publication": "Wang18",
         "bibcode": "2018PASP..130f4402W",
         "doi": null,
         "description": null
     },
     {
-        "name": "Bedi17",
+        "publication": "Bedi17",
         "bibcode": "2017MNRAS.470.1140B",
         "doi": null,
         "description": null
     },
     {
-        "name": "Delo17b",
+        "publication": "Delo17b",
         "bibcode": "2017A&A...608A..79D",
         "doi": null,
         "description": null
     },
     {
-        "name": "Luhm16",
+        "publication": "Luhm16",
         "bibcode": "2016AJ....152...78L",
         "doi": null,
         "description": null
     },
     {
-        "name": "Legg17",
+        "publication": "Legg17",
         "bibcode": "2017ApJ...842..118L",
         "doi": "10.3847/1538-4357/aa6fb5",
         "description": "The Y-type Brown Dwarfs: Estimates of Mass and Age from New Astrometry, Homogenized Photometry, and Near-infrared Spectroscopy"
     },
     {
-        "name": "Card12",
+        "publication": "Card12",
         "bibcode": "2012PhDT.........?C",
         "doi": null,
         "description": "Observational properties of brown dwarfs: The low-mass end of the mass function"
     },
     {
-        "name": "Tria20",
+        "publication": "Tria20",
         "bibcode": "2020NatAs...4..650T",
         "doi": "10.1038/s41550-020-1018-2",
         "description": "An eclipsing substellar binary in a young triple system discovered by SPECULOOS"
     },
     {
-        "name": "Aber14b",
+        "publication": "Aber14b",
         "bibcode": "2014AJ....148..129A",
         "doi": "10.1088/0004-6256/148/6/129",
         "description": "Constraints on the Binary Properties of Mid- to Late T Dwarfs from Hubble Space Telescope WFC3 Observations"
     },
     {
-        "name": "Adam11",
+        "publication": "Adam11",
         "bibcode": "2011ApJ...726L...3A",
         "doi": "10.1088/2041-8205/726/1/L3",
         "description": "Spitzer Spectroscopy of the Circumprimary Disk in the Binary Brown Dwarf 2MASS J04414489+2301513"
     },
     {
-        "name": "Adel07",
+        "publication": "Adel07",
         "bibcode": "2007ApJS..172..634A",
         "doi": "10.1086/518864",
         "description": "The Fifth Data Release of the Sloan Digital Sky Survey"
     },
     {
-        "name": "Alca20",
+        "publication": "Alca20",
         "bibcode": "2020A&A...635L...1A",
         "doi": "10.1051/0004-6361/201937309",
         "description": "2MASS J15491331-3539118: a new low-mass wide companion of the GQ Lup system"
     },
     {
-        "name": "Alle06",
+        "publication": "Alle06",
         "bibcode": "2006ApJ...644..364A",
         "doi": "10.1086/503355",
         "description": "Young, Low-Mass Brown Dwarfs with Mid-Infrared Excesses"
     },
     {
-        "name": "Alle07b",
+        "publication": "Alle07b",
         "bibcode": "2007AJ....133..971A",
         "doi": "10.1086/510346",
         "description": "A New Brown Dwarf Desert? A Scarcity of Wide Ultracool Binaries"
     },
     {
-        "name": "Alle12",
+        "publication": "Alle12",
         "bibcode": "2012AJ....144...62A",
         "doi": "10.1088/0004-6256/144/2/62",
         "description": "Low-mass Tertiary Companions to Spectroscopic Binaries. I. Common Proper Motion Survey for Wide Companions Using 2MASS"
     },
     {
-        "name": "Alle13b",
+        "publication": "Alle13b",
         "bibcode": "2013ApJ...773...63A",
         "doi": "10.1088/0004-637X/773/1/63",
         "description": "A Pan-STARRS + UKIDSS Search for Young, Wide Planetary-mass Companions in Upper Scorpius"
     },
     {
-        "name": "Alle13c",
+        "publication": "Alle13c",
         "bibcode": "2013MmSAI..84.1089A",
         "doi": null,
         "description": "A near-infrared spectroscopic study of young field ultracool dwarfs: additional analysis"
     },
     {
-        "name": "Alle16",
+        "publication": "Alle16",
         "bibcode": "2016ApJ...821..120A",
         "doi": "10.3847/0004-637X/821/2/120",
         "description": "Brown Dwarfs in Young Moving Groups from Pan-STARRS1. I. AB Doradus"
     },
     {
-        "name": "Altm17",
+        "publication": "Altm17",
         "bibcode": "2017A&A...600L...4A",
         "doi": "10.1051/0004-6361/201730393",
         "description": "Hot Stuff for One Year (HSOY). A 583 million star proper motion catalogue derived from Gaia DR1 and PPMXL"
     },
     {
-        "name": "Alve13a",
+        "publication": "Alve13a",
         "bibcode": "2013A&A...549A.123A",
         "doi": "10.1051/0004-6361/201220229",
         "description": "Spectroscopy of brown dwarf candidates in IC 348 and the determination of its substellar IMF down to planetary masses"
     },
     {
-        "name": "Ardi00",
+        "publication": "Ardi00",
         "bibcode": "2000AJ....120..479A",
         "doi": "10.1086/301443",
         "description": "A Survey for Low-Mass Stars and Brown Dwarfs in the Upper Scorpius OB Association"
     },
     {
-        "name": "Arti11",
+        "publication": "Arti11",
         "bibcode": "2011ApJ...739...48A",
         "doi": "10.1088/0004-637X/739/1/48",
         "description": "Discovery of Two L and T Binaries with Wide Separations and Peculiar Photometric Properties"
     },
     {
-        "name": "Bail14",
+        "publication": "Bail14",
         "bibcode": "2014ApJ...780L...4B",
         "doi": "10.1088/2041-8205/780/1/L4",
         "description": "HD 106906 b: A Planetary-mass Companion Outside a Massive Debris Disk"
     },
     {
-        "name": "Bard15",
+        "publication": "Bard15",
         "bibcode": "2015AJ....150..163B",
         "doi": "10.1088/0004-6256/150/5/163",
         "description": "High Resolution Imaging of Very Low Mass Spectral Binaries: Three Resolved Systems and Detection of Orbital Motion in an L/T Transition Binary"
     },
     {
-        "name": "Baro15",
+        "publication": "Baro15",
         "bibcode": "2015ApJ...802...37B",
         "doi": "10.1088/0004-637X/802/1/37",
         "description": "Discovery and Characterization of Wide Binary Systems with a Very Low Mass Component"
     },
     {
-        "name": "Barr01f",
+        "publication": "Barr01f",
         "bibcode": "2001A&A...377L...9B",
         "doi": "10.1051/0004-6361:20011152",
         "description": "Optical spectroscopy of isolated planetary mass objects in the \u03c3 Orionis cluster"
     },
     {
-        "name": "Barr02a",
+        "publication": "Barr02a",
         "bibcode": "2002A&A...393L..85B",
         "doi": "10.1051/0004-6361:20021251",
         "description": "Discovery of a very cool object with extraordinarily strong H\u03b1 emission"
     },
     {
-        "name": "Barr03a",
+        "publication": "Barr03a",
         "bibcode": "2003A&A...404..171B",
         "doi": "10.1051/0004-6361:20030407",
         "description": "The sigma  Orionis substellar population.  VLT/FORS spectroscopy and 2MASS photometry"
     },
     {
-        "name": "Bart07",
+        "publication": "Bart07",
         "bibcode": "2007PhDT.........2B",
         "doi": null,
         "description": "Knowing our neighbors: Fundamental properties of nearby stars"
     },
     {
-        "name": "Bart17",
+        "publication": "Bart17",
         "bibcode": "2017AJ....154..151B",
         "doi": "10.3847/1538-3881/aa8457",
         "description": "The Solar Neighborhood. XXXX. Parallax Results from the CTIOPI 0.9 m Program: New Young Stars Near the Sun"
     },
     {
-        "name": "Basr00",
+        "publication": "Basr00",
         "bibcode": "2000ApJ...538..363B",
         "doi": "10.1086/309095",
         "description": "An Effective Temperature Scale for Late-M and L Dwarfs, from Resonance Absorption Lines of Cs I and Rb I"
     },
     {
-        "name": "Beam13",
+        "publication": "Beam13",
         "bibcode": "2013A&A...557L...8B",
         "doi": "10.1051/0004-6361/201322190",
         "description": "One more neighbor: The first brown dwarf in the VVV survey"
     },
     {
-        "name": "Beam14",
+        "publication": "Beam14",
         "bibcode": "2014A&A...570L...8B",
         "doi": "10.1051/0004-6361/201424505",
         "description": "Temperature constraints on the coldest brown dwarf known: WISE 0855-0714"
     },
     {
-        "name": "Beam15",
+        "publication": "Beam15",
         "bibcode": "2015MNRAS.454.4054B",
         "doi": "10.1093/mnras/stv2241",
         "description": "Spectrophotometric characterization of high proper motion sources from WISE"
     },
     {
-        "name": "Beam17",
+        "publication": "Beam17",
         "bibcode": "2018RMxAC..50...55B",
         "doi": null,
         "description": "Near-IR trigonometric parallaxes of nearby stars in the Galactic plane using the VVV survey"
     },
     {
-        "name": "Beja08",
+        "publication": "Beja08",
         "bibcode": "2008ApJ...673L.185B",
         "doi": "10.1086/527557",
         "description": "Discovery of a Wide Companion near the Deuterium-burning Mass Limit in the Upper Scorpius Association"
     },
     {
-        "name": "Berd17",
+        "publication": "Berd17",
         "bibcode": "2017ApJ...847...61B",
         "doi": "10.3847/1538-4357/aa866b",
         "description": "First Detection of a Strong Magnetic Field on a Bursty Brown Dwarf: Puzzle Solved"
     },
     {
-        "name": "Berg10",
+        "publication": "Berg10",
         "bibcode": "2010A&A...520A..54B",
         "doi": "10.1051/0004-6361/201014114",
         "description": "Lucky Imaging survey for southern M dwarf binaries"
     },
     {
-        "name": "Berr03",
+        "publication": "Berr03",
         "bibcode": "2003IAUJD...8E..60B",
         "doi": null,
         "description": "Discover of Brown Dwarfs with Virtual Observatories"
     },
     {
-        "name": "Bess91b",
+        "publication": "Bess91b",
         "bibcode": "1991AJ....101..662B",
         "doi": "10.1086/115714",
         "description": "The Late M Dwarfs"
     },
     {
-        "name": "Best13",
+        "publication": "Best13",
         "bibcode": "2013ApJ...777...84B",
         "doi": "10.1088/0004-637X/777/2/84",
         "description": "A Search for L/T Transition Dwarfs with Pan-STARRS1 and WISE: Discovery of Seven Nearby Objects Including Two Candidate Spectroscopic Variables"
     },
     {
-        "name": "Best17a",
+        "publication": "Best17a",
         "bibcode": "2017ApJ...837...95B",
         "doi": "10.3847/1538-4357/aa5df0",
         "description": "A Search for L/T Transition Dwarfs with Pan-STARRS1 and WISE. III. Young L Dwarf Discoveries and Proper Motion Catalogs in Taurus and Scorpius-Centaurus"
     },
     {
-        "name": "Best17b",
+        "publication": "Best17b",
         "bibcode": "2017ApJ...843L...4B",
         "doi": "10.3847/2041-8213/aa76df",
         "description": "The Young L Dwarf 2MASS J11193254-1137466 Is a Planetary-mass Binary"
     },
     {
-        "name": "Best20a",
+        "publication": "Best20a",
         "bibcode": "2020AJ....159..257B",
         "doi": "10.3847/1538-3881/ab84f4",
         "description": "The Hawaii Infrared Parallax Program. IV. A Comprehensive Parallax Survey of L0-T8 Dwarfs with UKIRT"
     },
     {
-        "name": "Best20b",
+        "publication": "Best20b",
         "bibcode": "2021AJ....161...42B",
         "doi": "10.3847/1538-3881/abc893",
         "description": "A Volume-limited Sample of Ultracool Dwarfs. I. Construction, Space Density, and a Gap in the L/T Transition"
     },
     {
-        "name": "Biha09",
+        "publication": "Biha09",
         "bibcode": "2009A&A...506.1169B",
         "doi": "10.1051/0004-6361/200912210",
         "description": "Candidate free-floating super-Jupiters in the young \u03c3 Orionis open cluster"
     },
     {
-        "name": "Biha13",
+        "publication": "Biha13",
         "bibcode": "2013A&A...557A..43B",
         "doi": "10.1051/0004-6361/201322141",
         "description": "An overlooked brown dwarf neighbour (T7.5 at d ~ 5 pc) of the Sun and two additional T dwarfs at about 10 pc"
     },
     {
-        "name": "Bill05",
+        "publication": "Bill05",
         "bibcode": "2005A&A...440L..55B",
         "doi": "10.1051/0004-6361:200500167",
         "description": "The first wide ultracool binary dwarf in the field: DENIS-J055146.0-443412.2 (M8.5 + L0)"
     },
     {
-        "name": "Bill13",
+        "publication": "Bill13",
         "bibcode": "2013ApJ...777..160B",
         "doi": "10.1088/0004-637X/777/2/160",
         "description": "The Gemini/NICI Planet-Finding Campaign: The Frequency of Planets around Young Moving Group Stars"
     },
     {
-        "name": "Blak08a",
+        "publication": "Blak08a",
         "bibcode": "2008ApJ...678L.125B",
         "doi": "10.1086/588754",
         "description": "A Spectroscopic Binary at the M/L Transition"
     },
     {
-        "name": "Boch05",
+        "publication": "Boch05",
         "bibcode": "2005AJ....130.1871B",
         "doi": "10.1086/444417",
         "description": "Spectroscopic Survey of M Dwarfs within 100 Parsecs of the Sun"
     },
     {
-        "name": "Boes76",
+        "publication": "Boes76",
         "bibcode": "1976PhDT........14B",
         "doi": null,
         "description": "The Spectral Classification of M-Dwarf Stars."
     },
     {
-        "name": "Bonn09",
+        "publication": "Bonn09",
         "bibcode": "2009A&A...506..799B",
         "doi": "10.1051/0004-6361/200810921",
         "description": "The young, tight, and low-mass binary TWA22AB: a new calibrator for evolutionary models?. Orbit, spectral types, and temperature"
     },
     {
-        "name": "Bonn18",
+        "publication": "Bonn18",
         "bibcode": "2018A&A...618A..63B",
         "doi": "10.1051/0004-6361/201832942",
         "description": "The GJ 504 system revisited. Combining interferometric, radial velocity, and high contrast imaging data"
     },
     {
-        "name": "Boud13",
+        "publication": "Boud13",
         "bibcode": "2013MNRAS.434..142B",
         "doi": "10.1093/mnras/stt1009",
         "description": "The first spectroscopically identified L dwarf in Praesepe"
     },
     {
-        "name": "Bouy06a",
+        "publication": "Bouy06a",
         "bibcode": "2006ApJ...637.1056B",
         "doi": "10.1086/498350",
         "description": "A Hubble Space Telescope Advanced Camera for Surveys Search for Brown Dwarf Binaries in the Pleiades Open Cluster"
     },
     {
-        "name": "Bouy15b",
+        "publication": "Bouy15b",
         "bibcode": "2015A&A...577A.148B",
         "doi": "10.1051/0004-6361/201425019",
         "description": "The Seven Sisters DANCe. I. Empirical isochrones, luminosity, and mass functions of the Pleiades cluster"
     },
     {
-        "name": "Bowl14",
+        "publication": "Bowl14",
         "bibcode": "2014ApJ...784...65B",
         "doi": "10.1088/0004-637X/784/1/65",
         "description": "Spectroscopic Confirmation of Young Planetary-mass Companions on Wide Orbits"
     },
     {
-        "name": "Bowl15",
+        "publication": "Bowl15",
         "bibcode": "2015ApJS..216....7B",
         "doi": "10.1088/0067-0049/216/1/7",
         "description": "Planets around Low-mass Stars (PALMS). IV. The Outer Architecture of M Dwarf Planetary Systems"
     },
     {
-        "name": "Bowl16",
+        "publication": "Bowl16",
         "bibcode": "2016PASP..128j2001B",
         "doi": "10.1088/1538-3873/128/968/102001",
         "description": "Imaging Extrasolar Giant Planets"
     },
     {
-        "name": "Bowl17a",
+        "publication": "Bowl17a",
         "bibcode": "2017AJ....153...18B",
         "doi": "10.3847/1538-3881/153/1/18",
         "description": "Planets around Low-mass Stars (PALMS). VI. Discovery of a Remarkably Red Planetary-mass Companion to the AB Dor Moving Group Candidate 2MASS J22362452+4751425*"
     },
     {
-        "name": "Bowl17b",
+        "publication": "Bowl17b",
         "bibcode": "2017AJ....154..165B",
         "doi": "10.3847/1538-3881/aa88bd",
         "description": "The Young Substellar Companion ROXs 12 B: Near-infrared Spectrum, System Architecture, and Spin-Orbit Misalignment"
     },
     {
-        "name": "Bram08",
+        "publication": "Bram08",
         "bibcode": "2008MNRAS.386..887B",
         "doi": "10.1111/j.1365-2966.2008.13053.x",
         "description": "Light and motion in SDSS Stripe 82: the catalogues"
     },
     {
-        "name": "Bryj92",
+        "publication": "Bryj92",
         "bibcode": "1992ApJ...388L..23B",
         "doi": "10.1086/186321",
         "description": "Candidate Brown Dwarfs in the Hyades"
     },
     {
-        "name": "Bryj94",
+        "publication": "Bryj94",
         "bibcode": "1994AJ....107..246B",
         "doi": "10.1086/116848",
         "description": "The Lowest Mass Stars in the Hyades"
     },
     {
-        "name": "Buen14",
+        "publication": "Buen14",
         "bibcode": "2014ApJ...782...77B",
         "doi": "10.1088/0004-637X/782/2/77",
         "description": "Brown Dwarf Photospheres are Patchy: A Hubble Space Telescope Near-infrared Spectroscopic Survey Finds Frequent Low-level Variability"
     },
     {
-        "name": "Buen15a",
+        "publication": "Buen15a",
         "bibcode": "2015ApJ...798..127B",
         "doi": "10.1088/0004-637X/798/2/127",
         "description": "Cloud Structure of the Nearest Brown Dwarfs: Spectroscopic Variability of Luhman 16AB from the Hubble Space Telescope"
     },
     {
-        "name": "Burg15c",
+        "publication": "Burg15c",
         "bibcode": "2015AJ....150..180B",
         "doi": "10.1088/0004-6256/150/6/180",
         "description": "Radio Emission and Orbital Motion from the Close-encounter Star-Brown Dwarf Binary WISE J072003.20-084651.2"
     },
     {
-        "name": "Burg16a",
+        "publication": "Burg16a",
         "bibcode": "2016ApJ...820...32B",
         "doi": "10.3847/0004-637X/820/1/32",
         "description": "The First Brown Dwarf/Planetary-mass Object in the 32 Orionis Group"
     },
     {
-        "name": "Burg16b",
+        "publication": "Burg16b",
         "bibcode": "2016ApJ...827...25B",
         "doi": "10.3847/0004-637X/827/1/25",
         "description": "The Orbit of the L Dwarf + T Dwarf Spectral Binary SDSS J080531.84+481233.0"
     },
     {
-        "name": "Burn10b",
+        "publication": "Burn10b",
         "bibcode": "2010MNRAS.406.1885B",
         "doi": "10.1111/j.1365-2966.2010.16800.x",
         "description": "47 new T dwarfs from the UKIDSS Large Area Survey"
     },
     {
-        "name": "Burn11b",
+        "publication": "Burn11b",
         "bibcode": "2011MNRAS.414L..90B",
         "doi": "10.1111/j.1745-3933.2011.01062.x",
         "description": "The discovery of the T8.5 dwarf UGPS J0521+3640"
     },
     {
-        "name": "Burn14",
+        "publication": "Burn14",
         "bibcode": "2014MNRAS.440..359B",
         "doi": "10.1093/mnras/stu184",
         "description": "The discovery of a T6.5 subdwarf"
     },
     {
-        "name": "Caba07a",
+        "publication": "Caba07a",
         "bibcode": "2007A&A...462L..61C",
         "doi": "10.1051/0004-6361:20066814",
         "description": "The widest ultracool binary"
     },
     {
-        "name": "Caba07e",
+        "publication": "Caba07e",
         "bibcode": "2007ApJ...667..520C",
         "doi": "10.1086/520873",
         "description": "Southern Very Low Mass Stars and Brown Dwarfs in Wide Binary and Multiple Systems"
     },
     {
-        "name": "Caba12b",
+        "publication": "Caba12b",
         "bibcode": "2012Obs...132..176C",
         "doi": null,
         "description": "Cool dwarfs in wide multiple systems - Paper 2: A distant M8.5 V companion to HD 212168 AB"
     },
     {
-        "name": "Cali19",
+        "publication": "Cali19",
         "bibcode": "2019A&A...627A.167C",
         "doi": "10.1051/0004-6361/201935319",
         "description": "Spectral characterization of newly detected young substellar binaries with SINFONI"
     },
     {
-        "name": "Card15",
+        "publication": "Card15",
         "bibcode": "2015MNRAS.450.2486C",
         "doi": "10.1093/mnras/stv380",
         "description": "49 new T dwarfs identified using methane imaging"
     },
     {
-        "name": "Cars13",
+        "publication": "Cars13",
         "bibcode": "2013ApJ...763L..32C",
         "doi": "10.1088/2041-8205/763/2/L32",
         "description": "Direct Imaging Discovery of a \"Super-Jupiter\" around the Late B-type Star  \u03ba  And"
     },
     {
-        "name": "Case08",
+        "publication": "Case08",
         "bibcode": "2008MNRAS.390.1517C",
         "doi": "10.1111/j.1365-2966.2008.13855.x",
         "description": "Proper motions of field L and T dwarfs - II"
     },
     {
-        "name": "Cast12",
+        "publication": "Cast12",
         "bibcode": "2012ApJ...746....3C",
         "doi": "10.1088/0004-637X/746/1/3",
         "description": "Discovery of a Late L Dwarf: WISEP J060738.65+242953.4"
     },
     {
-        "name": "Cast13",
+        "publication": "Cast13",
         "bibcode": "2013ApJ...776..126C",
         "doi": "10.1088/0004-637X/776/2/126",
         "description": "Discovery of Four High Proper Motion L Dwarfs, Including a 10 pc L Dwarf at the L/T Transition"
     },
     {
-        "name": "Cast16",
+        "publication": "Cast16",
         "bibcode": "2016ApJ...816...78C",
         "doi": "10.3847/0004-637X/816/2/78",
         "description": "Discovery of an L4 beta Candidate Member of Argus in the Planetary Mass Regime: Wise J231921.92+764544.4"
     },
     {
-        "name": "Chau03a",
+        "publication": "Chau03a",
         "bibcode": "2003A&A...404..157C",
         "doi": "10.1051/0004-6361:20030352",
         "description": "Adaptive optics imaging survey of the Tucana-Horologium association"
     },
     {
-        "name": "Chau05a",
+        "publication": "Chau05a",
         "bibcode": "2005A&A...430.1027C",
         "doi": "10.1051/0004-6361:20041353",
         "description": "Astrometric and spectroscopic confirmation of a brown dwarf companion to GSC 08047-00232.  VLT/NACO deep imaging and spectroscopic observations"
     },
     {
-        "name": "Chau05b",
+        "publication": "Chau05b",
         "bibcode": "2005A&A...438L..25C",
         "doi": "10.1051/0004-6361:200500116",
         "description": "Giant planet companion to 2MASSW J1207334-393254"
     },
     {
-        "name": "Chau12b",
+        "publication": "Chau12b",
         "bibcode": "2012A&A...548A..33C",
         "doi": "10.1051/0004-6361/201219446",
         "description": "Deep search for companions to probable young brown dwarfs. VLT/NACO adaptive optics imaging using IR wavefront sensing"
     },
     {
-        "name": "Chau17",
+        "publication": "Chau17",
         "bibcode": "2017A&A...605L...9C",
         "doi": "10.1051/0004-6361/201731152",
         "description": "Discovery of a warm, dusty giant planet around HIP 65426"
     },
     {
-        "name": "Chee19",
+        "publication": "Chee19",
         "bibcode": "2019A&A...622A..80C",
         "doi": "10.1051/0004-6361/201834112",
         "description": "Spectral and orbital characterisation of the directly imaged giant planet HIP 65426 b"
     },
     {
-        "name": "Chen11",
+        "publication": "Chen11",
         "bibcode": "2011ApJ...738..122C",
         "doi": "10.1088/0004-637X/738/2/122",
         "description": "A Magellan MIKE and Spitzer MIPS Study of 1.5-1.0 M <SUB>sun</SUB> Stars in Scorpius-Centaurus"
     },
     {
-        "name": "Chiu08",
+        "publication": "Chiu08",
         "bibcode": "2008MNRAS.385L..53C",
         "doi": "10.1111/j.1745-3933.2008.00432.x",
         "description": "Four faint T dwarfs from the UKIRT Infrared Deep Sky Survey (UKIDSS) Southern Stripe"
     },
     {
-        "name": "Chri19",
+        "publication": "Chri19",
         "bibcode": "2019ApJ...877L..33C",
         "doi": "10.3847/2041-8213/ab212b",
         "description": "Evidence for a Circumplanetary Disk around Protoplanet PDS 70 b"
     },
     {
-        "name": "Clos02a",
+        "publication": "Clos02a",
         "bibcode": "2002ApJ...566.1095C",
         "doi": "10.1086/337916",
         "description": "Discovery of a 0.15\" Binary Brown Dwarf, 2MASS J1426316+155701, with Gemini/Hokupa'a Adaptive Optics"
     },
     {
-        "name": "Crep14a",
+        "publication": "Crep14a",
         "bibcode": "2014ApJ...781...29C",
         "doi": "10.1088/0004-637X/781/1/29",
         "description": "The TRENDS High-contrast Imaging Survey. V. Discovery of an Old and Cold Benchmark T-dwarf Orbiting the Nearby G-star HD 19467"
     },
     {
-        "name": "Crep15",
+        "publication": "Crep15",
         "bibcode": "2015ApJ...798L..43C",
         "doi": "10.1088/2041-8205/798/2/L43",
         "description": "Direct Spectrum of the Benchmark T Dwarf HD 19467 B"
     },
     {
-        "name": "Crep16",
+        "publication": "Crep16",
         "bibcode": "2016ApJ...831..136C",
         "doi": "10.3847/0004-637X/831/2/136",
         "description": "The TRENDS High-contrast Imaging Survey. VI. Discovery of a Mass, Age, and Metallicity Benchmark Brown Dwarf"
     },
     {
-        "name": "Cros12",
+        "publication": "Cros12",
         "bibcode": "2012A&A...548A.119C",
         "doi": "10.1051/0004-6361/201219505",
         "description": "The VISTA Science Archive"
     },
     {
-        "name": "Cuby99",
+        "publication": "Cuby99",
         "bibcode": "1999A&A...349L..41C",
         "doi": null,
         "description": "Discovery of a faint field methane brown dwarf from ES0 NTT and VLT observations"
     },
     {
-        "name": "Curr14a",
+        "publication": "Curr14a",
         "bibcode": "2014ApJ...780L..30C",
         "doi": "10.1088/2041-8205/780/2/L30",
         "description": "Direct Imaging and Spectroscopy of a Candidate Companion Below/Near the Deuterium-burning Limit in the Young Binary Star System, ROXs 42B"
     },
     {
-        "name": "Curr14b",
+        "publication": "Curr14b",
         "bibcode": "2014ApJ...787..104C",
         "doi": "10.1088/0004-637X/787/2/104",
         "description": "A First-look Atmospheric Modeling Study of the Young Directly Imaged Planet-mass Companion, ROXs 42Bb"
     },
     {
-        "name": "Curr18",
+        "publication": "Curr18",
         "bibcode": "2018AJ....156..291C",
         "doi": "10.3847/1538-3881/aae9ea",
         "description": "SCExAO/CHARIS Near-infrared Direct Imaging, Spectroscopy, and Forward-Modeling of \u03ba And b: A Likely Young, Low-gravity Superjovian Companion"
     },
     {
-        "name": "Curr19",
+        "publication": "Curr19",
         "bibcode": "2019ApJ...877L...3C",
         "doi": "10.3847/2041-8213/ab1b42",
         "description": "No Clear, Direct Evidence for Multiple Protoplanets Orbiting LkCa 15: LkCa 15 bcd are Likely Inner Disk Signals"
     },
     {
-        "name": "Cush16",
+        "publication": "Cush16",
         "bibcode": "2016ApJ...823..152C",
         "doi": "10.3847/0004-637X/823/2/152",
         "description": "The First Detection of Photometric Variability in a Y Dwarf: WISE J140518.39+553421.3"
     },
     {
-        "name": "Daem17",
+        "publication": "Daem17",
         "bibcode": "2017A&A...608A..71D",
         "doi": "10.1051/0004-6361/201731527",
         "description": "High signal-to-noise spectral characterization of the planetary-mass object HD 106906 b"
     },
     {
-        "name": "Dahn86",
+        "publication": "Dahn86",
         "bibcode": "1986AJ.....91..621D",
         "doi": "10.1086/114044",
         "description": "LHS 292 and the luminosity function of the nearby M dwarfs."
     },
     {
-        "name": "Daws14",
+        "publication": "Daws14",
         "bibcode": "2014MNRAS.442.1586D",
         "doi": "10.1093/mnras/stu973",
         "description": "Near-infrared spectroscopy of young brown dwarfs in upper Scorpius"
     },
     {
-        "name": "DayJ08",
+        "publication": "DayJ08",
         "bibcode": "2008MNRAS.388..838D",
         "doi": "10.1111/j.1365-2966.2008.13455.x",
         "description": "Discovery of a widely separated ultracool dwarf-white dwarf binary"
     },
     {
-        "name": "DayJ11",
+        "publication": "DayJ11",
         "bibcode": "2011MNRAS.410..705D",
         "doi": "10.1111/j.1365-2966.2010.17469.x",
         "description": "Discovery of a T dwarf + white dwarf binary system"
     },
     {
-        "name": "Deac05b",
+        "publication": "Deac05b",
         "bibcode": "2005A&A...435..363D",
         "doi": "10.1051/0004-6361:20042002",
         "description": "Southern infrared proper motion survey. I. Discovery of new high proper motion stars from first full hemisphere scan"
     },
     {
-        "name": "Deac09a",
+        "publication": "Deac09a",
         "bibcode": "2009MNRAS.394..857D",
         "doi": "10.1111/j.1365-2966.2008.14371.x",
         "description": "The UKIDSS-2MASS proper motion survey - I. Ultracool dwarfs from UKIDSS DR4"
     },
     {
-        "name": "Deac11",
+        "publication": "Deac11",
         "bibcode": "2011AJ....142...77D",
         "doi": "10.1088/0004-6256/142/3/77",
         "description": "Four New T Dwarfs Identified in Pan-STARRS 1 Commissioning Data"
     },
     {
-        "name": "Deac12a",
+        "publication": "Deac12a",
         "bibcode": "2012ApJ...755...94D",
         "doi": "10.1088/0004-637X/755/2/94",
         "description": "HIP 38939B: A New Benchmark T Dwarf in the Galactic Plane Discovered with Pan-STARRS1"
     },
     {
-        "name": "Deac12b",
+        "publication": "Deac12b",
         "bibcode": "2012ApJ...757..100D",
         "doi": "10.1088/0004-637X/757/1/100",
         "description": "LHS 2803B: A Very Wide Mid-T Dwarf Companion to an Old M Dwarf Identified from Pan-STARRS1"
     },
     {
-        "name": "Deac14b",
+        "publication": "Deac14b",
         "bibcode": "2014ApJ...792..119D",
         "doi": "10.1088/0004-637X/792/2/119",
         "description": "Wide Cool and Ultracool Companions to Nearby Stars from Pan-STARRS 1"
     },
     {
-        "name": "Deac16",
+        "publication": "Deac16",
         "bibcode": "2016MNRAS.457.3191D",
         "doi": "10.1093/mnras/stw172",
         "description": "A nearby young M dwarf with a wide, possibly planetary-mass companion"
     },
     {
-        "name": "Deac17a",
+        "publication": "Deac17a",
         "bibcode": "2017MNRAS.467.1126D",
         "doi": "10.1093/mnras/stx065",
         "description": "2MASS 0213+3648 C: A wide T3 benchmark companion to an active, old M dwarf binary"
     },
     {
-        "name": "Deac17b",
+        "publication": "Deac17b",
         "bibcode": "2017MNRAS.468.3499D",
         "doi": "10.1093/mnras/stx440",
         "description": "Identification of partially resolved binaries in Pan-STARRS 1 data"
     },
     {
-        "name": "Delf01",
+        "publication": "Delf01",
         "bibcode": "2001A&A...366L..13D",
         "doi": "10.1051/0004-6361:20010001",
         "description": "New neighbours: II. An M9 dwarf at d ~ 4 pc, DENIS-P J104814.7-395606.1"
     },
     {
-        "name": "Delf99b",
+        "publication": "Delf99b",
         "bibcode": "1999A&AS..135...41D",
         "doi": "10.1051/aas:1999158",
         "description": "Searching for very low-mass stars and brown dwarfs with DENIS"
     },
     {
-        "name": "Delo08b",
+        "publication": "Delo08b",
         "bibcode": "2008A&A...484..469D",
         "doi": "10.1051/0004-6361:20078843",
         "description": "Finding ultracool brown dwarfs with MegaCam on CFHT: method and first results"
     },
     {
-        "name": "Delo13",
+        "publication": "Delo13",
         "bibcode": "2013A&A...553L...5D",
         "doi": "10.1051/0004-6361/201321169",
         "description": "Direct-imaging discovery of a 12-14 Jupiter-mass object orbiting a young binary system of very low-mass stars"
     },
     {
-        "name": "Delo17",
+        "publication": "Delo17",
         "bibcode": "2017A&A...602A..82D",
         "doi": "10.1051/0004-6361/201629633",
         "description": "CFBDSIR 2149-0403: young isolated planetary-mass object or high-metallicity low-mass brown dwarf?"
     },
     {
-        "name": "DeRo14b",
+        "publication": "DeRo14b",
         "bibcode": "2014MNRAS.445.3694D",
         "doi": "10.1093/mnras/stu2018",
         "description": "The VAST Survey - IV. A wide brown dwarf companion to the A3V star \u03b6 Delphini"
     },
     {
-        "name": "DeRo16",
+        "publication": "DeRo16",
         "bibcode": "2016ApJ...824..121D",
         "doi": "10.3847/0004-637X/824/2/121",
         "description": "Spectroscopic Characterization of HD 95086 b with the Gemini Planet Imager"
     },
     {
-        "name": "DeRo19",
+        "publication": "DeRo19",
         "bibcode": "2019AJ....157..125D",
         "doi": "10.3847/1538-3881/ab0109",
         "description": "A Near-coplanar Stellar Flyby of the Planet Host Star HD 106906"
     },
     {
-        "name": "Desh12",
+        "publication": "Desh12",
         "bibcode": "2012AJ....144...99D",
         "doi": "10.1088/0004-6256/144/4/99",
         "description": "Intermediate Resolution Near-infrared Spectroscopy of 36 Late M Dwarfs"
     },
     {
-        "name": "deZe99",
+        "publication": "deZe99",
         "bibcode": "1999AJ....117..354D",
         "doi": "10.1086/300682",
         "description": "A HIPPARCOS Census of the Nearby OB Associations"
     },
     {
-        "name": "Dhit11",
+        "publication": "Dhit11",
         "bibcode": "2011AJ....141....7D",
         "doi": "10.1088/0004-6256/141/1/7",
         "description": "Resolved Spectroscopy of M Dwarf/L Dwarf Binaries. IV. Discovery of AN M9 + L6 Binary Separated by Over 100 AU"
     },
     {
-        "name": "Diaz13",
+        "publication": "Diaz13",
         "bibcode": "2013A&A...551L...9D",
         "doi": "10.1051/0004-6361/201321124",
         "description": "SOPHIE velocimetry of Kepler transit candidates. VIII. KOI-205 b: a brown-dwarf companion to a K-type dwarf"
     },
     {
-        "name": "Duco14",
+        "publication": "Duco14",
         "bibcode": "2014A&A...563A.121D",
         "doi": "10.1051/0004-6361/201322075",
         "description": "The TW Hydrae association: trigonometric parallaxes and kinematic analysis"
     },
     {
-        "name": "Duco17",
+        "publication": "Duco17",
         "bibcode": "2017A&A...597A..90D",
         "doi": "10.1051/0004-6361/201527574",
         "description": "Proper motion survey and kinematic analysis of the \u03c1 Ophiuchi embedded cluster"
     },
     {
-        "name": "Dupu16b",
+        "publication": "Dupu16b",
         "bibcode": "2016ApJ...827...23D",
         "doi": "10.3847/0004-637X/827/1/23",
         "description": "High-precision Radio and Infrared Astrometry of LSPM J1314+1320AB. II. Testing Pre-main-sequence Models at the Lithium Depletion Boundary with Dynamical Masses"
     },
     {
-        "name": "Dupu17",
+        "publication": "Dupu17",
         "bibcode": "2017ApJS..231...15D",
         "doi": "10.3847/1538-4365/aa5e4c",
         "description": "Individual Dynamical Masses of Ultracool Dwarfs"
     },
     {
-        "name": "Dupu18",
+        "publication": "Dupu18",
         "bibcode": "2018AJ....156...57D",
         "doi": "10.3847/1538-3881/aacbc2",
         "description": "The Hawaii Infrared Parallax Program. III. 2MASS J0249-0557 c: A Wide Planetary-mass Companion to a Low-mass Binary in the \u03b2 Pic Moving Group"
     },
     {
-        "name": "Dupu19",
+        "publication": "Dupu19",
         "bibcode": "2019AJ....158..174D",
         "doi": "10.3847/1538-3881/ab3cd1",
         "description": "WISE J072003.20-084651.2B is a Massive T Dwarf"
     },
     {
-        "name": "Dupu20",
+        "publication": "Dupu20",
         "bibcode": "2020RNAAS...4...54D",
         "doi": "10.3847/2515-5172/ab8942",
         "description": "The Parallax of VHS J1256-1257 from CFHT and Pan-STARRS-1"
     },
     {
-        "name": "Dye_18",
+        "publication": "Dye_18",
         "bibcode": "2018MNRAS.473.5113D",
         "doi": "10.1093/mnras/stx2622",
         "description": "The UKIRT Hemisphere Survey: definition and J-band data release"
     },
     {
-        "name": "Edge16",
+        "publication": "Edge16",
         "bibcode": "2016yCat.2343....0E",
         "doi": null,
         "description": "VizieR Online Data Catalog: VIKING catalogue data release 2 (Edge+, 2016)"
     },
     {
-        "name": "Elli05",
+        "publication": "Elli05",
         "bibcode": "2005AJ....130.2347E",
         "doi": "10.1086/491790",
         "description": "The 2MASS Wide-Field T Dwarf Search. V. Discovery of a T Dwarf via Methane Imaging"
     },
     {
-        "name": "Erik20",
+        "publication": "Erik20",
         "bibcode": "2020A&A...638L...6E",
         "doi": "10.1051/0004-6361/202038131",
         "description": "Strong H\u03b1 emission and signs of accretion in a circumbinary planetary mass companion from MUSE"
     },
     {
-        "name": "Eros99c",
+        "publication": "Eros99c",
         "bibcode": "1999A&A...351L...5E",
         "doi": null,
         "description": "EROS 2 proper motion survey: a field brown dwarf, and an L dwarf companion to LHS 102"
     },
     {
-        "name": "Espl17a",
+        "publication": "Espl17a",
         "bibcode": "2017AJ....154...46E",
         "doi": "10.3847/1538-3881/aa74e2",
         "description": "A Survey for Planetary-mass Brown Dwarfs in the Chamaeleon I Star-forming Region"
     },
     {
-        "name": "Espl17b",
+        "publication": "Espl17b",
         "bibcode": "2017AJ....154..134E",
         "doi": "10.3847/1538-3881/aa859b",
         "description": "A Survey For Planetary-mass Brown Dwarfs in the Taurus and Perseus Star-forming Regions"
     },
     {
-        "name": "Espo13",
+        "publication": "Espo13",
         "bibcode": "2013A&A...549A..52E",
         "doi": "10.1051/0004-6361/201219212",
         "description": "LBT observations of the HR 8799 planetary system. First detection of HR 8799e in H band"
     },
     {
-        "name": "Fahe14c",
+        "publication": "Fahe14c",
         "bibcode": "2014ApJ...793L..16F",
         "doi": "10.1088/2041-8205/793/1/L16",
         "description": "Indications of Water Clouds in the Coldest Known Brown Dwarf"
     },
     {
-        "name": "Finc16",
+        "publication": "Finc16",
         "bibcode": "2016AJ....151..160F",
         "doi": "10.3847/0004-6256/151/6/160",
         "description": "Parallax Results from URAT Epoch Data"
     },
     {
-        "name": "Folk07",
+        "publication": "Folk07",
         "bibcode": "2007MNRAS.378..901F",
         "doi": "10.1111/j.1365-2966.2007.11789.x",
         "description": "Discovery of a nearby L-T transition object in the Southern Galactic plane"
     },
     {
-        "name": "Folk12",
+        "publication": "Folk12",
         "bibcode": "2012MNRAS.427.3280F",
         "doi": "10.1111/j.1365-2966.2012.21132.x",
         "description": "Identifying ultra-cool dwarfs at low Galactic latitudes: a southern candidate catalogue"
     },
     {
-        "name": "Forb16",
+        "publication": "Forb16",
         "bibcode": "2016ApJ...827...22F",
         "doi": "10.3847/0004-637X/827/1/22",
         "description": "High-precision Radio and Infrared Astrometry of LSPM J1314+1320AB. I. Parallax, Proper Motions, and Limits on Planets"
     },
     {
-        "name": "Gagn17a",
+        "publication": "Gagn17a",
         "bibcode": "2017ApJS..228...18G",
         "doi": "10.3847/1538-4365/228/2/18",
         "description": "BANYAN. IX. The Initial Mass Function and Planetary-mass Object Space Density of the TW HYA Association"
     },
     {
-        "name": "Gagn17b",
+        "publication": "Gagn17b",
         "bibcode": "2017ApJ...841L...1G",
         "doi": "10.3847/2041-8213/aa70e2",
         "description": "SIMP J013656.5+093347 Is Likely a Planetary-mass Object in the Carina-Near Moving Group"
     },
     {
-        "name": "Gagn18a",
+        "publication": "Gagn18a",
         "bibcode": "2018ApJ...854L..27G",
         "doi": "10.3847/2041-8213/aaacfd",
         "description": "2MASS J13243553+6358281 Is an Early T-type Planetary-mass Object in the AB Doradus Moving Group"
     },
     {
-        "name": "Gagn18b",
+        "publication": "Gagn18b",
         "bibcode": "2018RNAAS...2...17G",
         "doi": "10.3847/2515-5172/aac0fd",
         "description": "A Gaia DR2 Confirmation that 2MASS J12074836-3900043 is a Member of the TW HYA Association"
     },
     {
-        "name": "Gagn18c",
+        "publication": "Gagn18c",
         "bibcode": "2018ApJ...862..138G",
         "doi": "10.3847/1538-4357/aaca2e",
         "description": "BANYAN. XIII. A First Look at Nearby Young Associations with Gaia Data Release 2"
     },
     {
-        "name": "GaiaDR2",
+        "publication": "GaiaDR2",
         "bibcode": "2018A&A...616A...1G",
         "doi": "10.1051/0004-6361/201833051",
         "description": "Gaia Data Release 2. Summary of the contents and survey properties"
     },
     {
-        "name": "Galv14",
+        "publication": "Galv14",
         "bibcode": "2014MNRAS.439.3890G",
         "doi": "10.1093/mnras/stu241",
         "description": "Spectroscopic signatures of youth in low-mass kinematic candidates of young moving groups"
     },
     {
-        "name": "Garc15",
+        "publication": "Garc15",
         "bibcode": "2015ApJ...804...65G",
         "doi": "10.1088/0004-637X/804/1/65",
         "description": "On the Binary Frequency of the Lowest Mass Members of the Pleiades with Hubble Space Telescope Wide Field Camera 3"
     },
     {
-        "name": "Garc17a",
+        "publication": "Garc17a",
         "bibcode": "2017ApJ...834..162G",
         "doi": "10.3847/1538-4357/834/2/162",
         "description": "SCExAO and GPI Y JHBand Photometry and Integral Field Spectroscopy of the Young Brown Dwarf Companion to HD 1160"
     },
     {
-        "name": "Garc17b",
+        "publication": "Garc17b",
         "bibcode": "2017ApJ...846...97G",
         "doi": "10.3847/1538-4357/aa844f",
         "description": "Individual, Model-independent Masses of the Closest Known Brown Dwarf Binary to the Sun"
     },
     {
-        "name": "Gate08",
+        "publication": "Gate08",
         "bibcode": "2008AJ....136..452G",
         "doi": "10.1088/0004-6256/136/1/452",
         "description": "Astrometric Studies of Aldebaran, Arcturus, Vega, the Hyades, and Other Regions"
     },
     {
-        "name": "Gauz12",
+        "publication": "Gauz12",
         "bibcode": "2012MNRAS.427.2457G",
         "doi": "10.1111/j.1365-2966.2012.22113.x",
         "description": "A new L dwarf member of the moderately metal poor triple system HD 221356"
     },
     {
-        "name": "Gauz19",
+        "publication": "Gauz19",
         "bibcode": "2019MNRAS.487.1149G",
         "doi": "10.1093/mnras/stz1284",
         "description": "A low-mass triple system with a wide L/T transition brown dwarf component: NLTT 51469AB/SDSS 2131-0119"
     },
     {
-        "name": "Gawr17",
+        "publication": "Gawr17",
         "bibcode": "2017MNRAS.466.4211G",
         "doi": "10.1093/mnras/stw3329",
         "description": "Physical properties and astrometry of radio-emitting brown dwarf TVLM 513-46546 revisited"
     },
     {
-        "name": "Geis11",
+        "publication": "Geis11",
         "bibcode": "2011ApJ...732...56G",
         "doi": "10.1088/0004-637X/732/1/56",
         "description": "A Cross-match of 2MASS and SDSS. II. Peculiar L Dwarfs, Unresolved Binaries, and the Space Density of T Dwarf Secondaries"
     },
     {
-        "name": "Giam86",
+        "publication": "Giam86",
         "bibcode": "1986ApJ...305..784G",
         "doi": "10.1086/164291",
         "description": "High-Resolution H alpha Observations of M Dwarf Stars: Implications for Stellar Dynamo Models and Stellar Kinematic Properties at Faint Magnitudes"
     },
     {
-        "name": "Gicl67a",
+        "publication": "Gicl67a",
         "bibcode": "1967LowOB...7....1G",
         "doi": null,
         "description": "Lowell proper motions X : proper motion survey of the Northern Hemisphere with the 13-inch photographic telescope of the Lowell Observatory"
     },
     {
-        "name": "Gicl71",
+        "publication": "Gicl71",
         "bibcode": "1971lpms.book.....G",
         "doi": null,
         "description": "Lowell proper motion survey Northern Hemisphere. The G numbered stars. 8991 stars fainter than magnitude 8 with motions &gt; 0\".26/year"
     },
     {
-        "name": "Gilm85",
+        "publication": "Gilm85",
         "bibcode": "1985MNRAS.213..257G",
         "doi": "10.1093/mnras/213.2.257",
         "description": "New light on faint stars - VII. Luminosity and mass distributions in two high galactic latitude fields."
     },
     {
-        "name": "Gins14b",
+        "publication": "Gins14b",
         "bibcode": "2014MNRAS.444.2280G",
         "doi": "10.1093/mnras/stu1586",
         "description": "Astrometric follow-up observations of directly imaged sub-stellar companions to young stars and brown dwarfs"
     },
     {
-        "name": "Gira11",
+        "publication": "Gira11",
         "bibcode": "2011AJ....142...15G",
         "doi": "10.1088/0004-6256/142/1/15",
         "description": "The Southern Proper Motion Program. IV. The SPM4 Catalog"
     },
     {
-        "name": "Girv11",
+        "publication": "Girv11",
         "bibcode": "2011MNRAS.417.1210G",
         "doi": "10.1111/j.1365-2966.2011.19337.x",
         "description": "DA white dwarfs in Sloan Digital Sky Survey Data Release 7 and a search for infrared excess emission"
     },
     {
-        "name": "Gizi00a",
+        "publication": "Gizi00a",
         "bibcode": "2000MNRAS.311..385G",
         "doi": "10.1046/j.1365-8711.2000.03060.x",
         "description": "Two nearby M dwarf binaries from the Two Micron All Sky Survey"
     },
     {
-        "name": "Gizi01b",
+        "publication": "Gizi01b",
         "bibcode": "2001ApJ...551L.163G",
         "doi": "10.1086/320017",
         "description": "Substellar Companions to Main-Sequence Stars: No Brown Dwarf Desert at Wide Separations"
     },
     {
-        "name": "Gizi11a",
+        "publication": "Gizi11a",
         "bibcode": "2011ApJ...736L..34G",
         "doi": "10.1088/2041-8205/736/2/L34",
         "description": "A Very High Proper Motion Star and the First L Dwarf in the Kepler Field"
     },
     {
-        "name": "Gizi11b",
+        "publication": "Gizi11b",
         "bibcode": "2011AJ....142..171G",
         "doi": "10.1088/0004-6256/142/5/171",
         "description": "WISEP J180026.60+013453.1: A nearby late-L Dwarf near the Galactic Plane"
     },
     {
-        "name": "Gizi13",
+        "publication": "Gizi13",
         "bibcode": "2013ApJ...779..172G",
         "doi": "10.1088/0004-637X/779/2/172",
         "description": "Kepler Monitoring of an L Dwarf I. The Photometric Period and White Light Flares"
     },
     {
-        "name": "Gizi15b",
+        "publication": "Gizi15b",
         "bibcode": "2015ApJ...813..104G",
         "doi": "10.1088/0004-637X/813/2/104",
         "description": "Kepler Monitoring of an L Dwarf. II. Clouds with Multi-year Lifetimes"
     },
     {
-        "name": "Gizi15c",
+        "publication": "Gizi15c",
         "bibcode": "2015AJ....150..179G",
         "doi": "10.1088/0004-6256/150/6/179",
         "description": "Properties of the nearby Brown Dwarf WISEP J180026.60+013453.1"
     },
     {
-        "name": "Gizi97b",
+        "publication": "Gizi97b",
         "bibcode": "1997PASP..109..849G",
         "doi": "10.1086/133955",
         "description": "Probing the LHS Catalog. I. New Nearby Stars and the Coolest Subdwarf"
     },
     {
-        "name": "Gizi97c",
+        "publication": "Gizi97c",
         "bibcode": "1997MNRAS.292L..41G",
         "doi": "10.1093/mnras/292.1.L41",
         "description": "APMPM J1523-0245: a new high proper motion cool subdwarf"
     },
     {
-        "name": "Gizi97d",
+        "publication": "Gizi97d",
         "bibcode": "1997PASP..109.1233G",
         "doi": "10.1086/134000",
         "description": "M Subdwarf Secondaries: A Test of the Metallicity Scale"
     },
     {
-        "name": "Gold08a",
+        "publication": "Gold08a",
         "bibcode": "2008A&A...487..277G",
         "doi": "10.1051/0004-6361:20065075",
         "description": "CLOUDS search for variability in brown dwarf atmospheres. Infrared spectroscopic time series of L/T transition brown dwarfs"
     },
     {
-        "name": "Gold08b",
+        "publication": "Gold08b",
         "bibcode": "2008A&A...490..763G",
         "doi": "10.1051/0004-6361:200810605",
         "description": "Binarity at the L/T brown dwarf transition. Adaptive optics search for companions"
     },
     {
-        "name": "Gome13",
+        "publication": "Gome13",
         "bibcode": "2013MNRAS.431.2745G",
         "doi": "10.1093/mnras/stt371",
         "description": "Two new ultracool benchmark systems from WISE+2MASS"
     },
     {
-        "name": "Grec19",
+        "publication": "Grec19",
         "bibcode": "2019AJ....158..182G",
         "doi": "10.3847/1538-3881/ab3ebe",
         "description": "Spectroscopic Follow-up of Discoveries from the NEOWISE Proper Motion Survey"
     },
     {
-        "name": "Grif98h",
+        "publication": "Grif98h",
         "bibcode": "1998Obs...118..273G",
         "doi": null,
         "description": "Spectroscopic binary orbits from photoelectric radial velocities. Paper 142: Xi Ursae Majoris"
     },
     {
-        "name": "Haff19",
+        "publication": "Haff19",
         "bibcode": "2019NatAs...3..749H",
         "doi": "10.1038/s41550-019-0780-5",
         "description": "Two accreting protoplanets around the young star PDS 70"
     },
     {
-        "name": "Hall02a",
+        "publication": "Hall02a",
         "bibcode": "2002ApJ...564L..89H",
         "doi": "10.1086/339020",
         "description": "2MASSI J1315309-264951: An L Dwarf with Strong and Variable H\u03b1 Emission"
     },
     {
-        "name": "Hall02d",
+        "publication": "Hall02d",
         "bibcode": "2002ApJ...580L..77H",
         "doi": "10.1086/345549",
         "description": "2MASS 1315-2649: A High Proper-Motion L Dwarf with Strong H\u03b1 Emission"
     },
     {
-        "name": "Hamb01a",
+        "publication": "Hamb01a",
         "bibcode": "2001MNRAS.326.1279H",
         "doi": "10.1111/j.1365-2966.2001.04660.x",
         "description": "The SuperCOSMOS Sky Survey - I. Introduction and description"
     },
     {
-        "name": "Hamb04a",
+        "publication": "Hamb04a",
         "bibcode": "2004A&A...415..265H",
         "doi": "10.1051/0004-6361:20034378",
         "description": "A new strongly X-ray flaring M 9 dwarf in the solar neighborhood"
     },
     {
-        "name": "Hamb04b",
+        "publication": "Hamb04b",
         "bibcode": "2004AJ....128..437H",
         "doi": "10.1086/421748",
         "description": "The Solar Neighborhood. VIII. Discovery of New High Proper Motion Nearby Stars Using the SuperCOSMOS Sky Survey"
     },
     {
-        "name": "Haro66",
+        "publication": "Haro66",
         "bibcode": "1966VA......8...89H",
         "doi": "10.1016/0083-6656(66)90024-9",
         "description": "Flare stars in stellar aggregates of different ages"
     },
     {
-        "name": "Harr15",
+        "publication": "Harr15",
         "bibcode": "2015csss...18..413H",
         "doi": null,
         "description": "Astrometric Orbits and Masses for Three Low-Mass Binaries"
     },
     {
-        "name": "Hash20",
+        "publication": "Hash20",
         "bibcode": "2020AJ....159..222H",
         "doi": "10.3847/1538-3881/ab811e",
         "description": "Accretion Properties of PDS 70b with MUSE"
     },
     {
-        "name": "Henr18",
+        "publication": "Henr18",
         "bibcode": "2018AJ....155..265H",
         "doi": "10.3847/1538-3881/aac262",
         "description": "The Solar Neighborhood XLIV: RECONS Discoveries within 10 parsecs"
     },
     {
-        "name": "Henr94",
+        "publication": "Henr94",
         "bibcode": "1994AJ....108.1437H",
         "doi": "10.1086/117167",
         "description": "The Solar Neighborhood. I. Standard Spectral Types (K5-M8) for Northern Dwarfs Within Eight Parsecs"
     },
     {
-        "name": "Henr97",
+        "publication": "Henr97",
         "bibcode": "1997AJ....114..388H",
         "doi": "10.1086/118482",
         "description": "The solar neighborhood IV: discovery of the twentieth nearest star"
     },
     {
-        "name": "Hern16",
+        "publication": "Hern16",
         "bibcode": "2016Natur.533..366H",
         "doi": "10.1038/nature17952",
         "description": "An irradiated brown-dwarf companion to an accreting white dwarf"
     },
     {
-        "name": "Hink13b",
+        "publication": "Hink13b",
         "bibcode": "2013ApJ...779..153H",
         "doi": "10.1088/0004-637X/779/2/153",
         "description": "The \u03ba Andromedae System: New Constraints on the Companion Mass, System Age, and Further Multiplicity"
     },
     {
-        "name": "Hog_98",
+        "publication": "Hog_98",
         "bibcode": "1998A&A...335L..65H",
         "doi": null,
         "description": "The TYCHO Reference Catalogue"
     },
     {
-        "name": "Hoga08",
+        "publication": "Hoga08",
         "bibcode": "2008MNRAS.388..495H",
         "doi": "10.1111/j.1365-2966.2008.13437.x",
         "description": "L dwarfs in the Hyades"
     },
     {
-        "name": "Huel15b",
+        "publication": "Huel15b",
         "bibcode": "2015A&A...578A...1H",
         "doi": "10.1051/0004-6361/201525634",
         "description": "WISE J061213.85-303612.5: a new T-dwarf binary candidate"
     },
     {
-        "name": "Iann95",
+        "publication": "Iann95",
         "bibcode": "1995ApJ...441L..47I",
         "doi": "10.1086/187786",
         "description": "The Brown Dwarf Candidate ESO 207-61: Its Distance and Very Low Luminosity"
     },
     {
-        "name": "Ingr14",
+        "publication": "Ingr14",
         "bibcode": "2014ApJ...794L..15I",
         "doi": "10.1088/2041-8205/794/1/L15",
         "description": "Gemini Planet Imager Spectroscopy of the HR 8799 Planets c and d"
     },
     {
-        "name": "Inne15",
+        "publication": "Inne15",
         "bibcode": "1915CiUO...30..235I",
         "doi": null,
         "description": "A Faint Star of Large Proper Motion"
     },
     {
-        "name": "Irel11a",
+        "publication": "Irel11a",
         "bibcode": "2011ApJ...726..113I",
         "doi": "10.1088/0004-637X/726/2/113",
         "description": "Two Wide Planetary-mass Companions to Solar-type Stars in Upper Scorpius"
     },
     {
-        "name": "Irel14",
+        "publication": "Irel14",
         "bibcode": "2014IAUS..299..199I",
         "doi": "10.1017/S1743921313008326",
         "description": "Orbital Motion and Multi-Wavelength Monitoring of LkCa15 b"
     },
     {
-        "name": "Isel19",
+        "publication": "Isel19",
         "bibcode": "2019ApJ...879L..25I",
         "doi": "10.3847/2041-8213/ab2a12",
         "description": "Detection of Continuum Submillimeter Emission Associated with Candidate Protoplanets"
     },
     {
-        "name": "Itoh05",
+        "publication": "Itoh05",
         "bibcode": "2005ApJ...620..984I",
         "doi": "10.1086/427086",
         "description": "A Young Brown Dwarf Companion to DH Tauri"
     },
     {
-        "name": "Jans12",
+        "publication": "Jans12",
         "bibcode": "2012ApJ...758L...2J",
         "doi": "10.1088/2041-8205/758/1/L2",
         "description": "New Brown Dwarf Companions to Young Stars in Scorpius-Centaurus"
     },
     {
-        "name": "Jans13d",
+        "publication": "Jans13d",
         "bibcode": "2013ApJ...778L...4J",
         "doi": "10.1088/2041-8205/778/1/L4",
         "description": "Direct Imaging Detection of Methane in the Atmosphere of GJ 504 b"
     },
     {
-        "name": "Jaya06b",
+        "publication": "Jaya06b",
         "bibcode": "2006Sci...313.1279J",
         "doi": "10.1126/science.1132128",
         "description": "Discovery of a Young Planetary-Mass Binary"
     },
     {
-        "name": "Joy_74",
+        "publication": "Joy_74",
         "bibcode": "1974ApJS...28....1J",
         "doi": "10.1086/190307",
         "description": "Spectral Types of M Dwarf Stars"
     },
     {
-        "name": "Kaka10",
+        "publication": "Kaka10",
         "bibcode": "2010ApJ...723..184K",
         "doi": "10.1088/0004-637X/723/1/184",
         "description": "Hawaii Quasar and T Dwarf Survey. I. Method and Discovery of Faint Field Ultracool Dwarfs"
     },
     {
-        "name": "Kell16",
+        "publication": "Kell16",
         "bibcode": "2016ApJ...821L..15K",
         "doi": "10.3847/2041-8205/821/1/L15",
         "description": "The Nearest Isolated Member of the TW Hydrae Association is a Giant Planet Analog"
     },
     {
-        "name": "Kell17",
+        "publication": "Kell17",
         "bibcode": "2017AJ....154..112K",
         "doi": "10.3847/1538-3881/aa83b0",
         "description": "A Statistical Survey of Peculiar L and T Dwarfs in SDSS, 2MASS, and WISE"
     },
     {
-        "name": "Kend07b",
+        "publication": "Kend07b",
         "bibcode": "2007A&A...466.1059K",
         "doi": "10.1051/0004-6361:20066403",
         "description": "Two T dwarfs from the UKIDSS early data release"
     },
     {
-        "name": "Kepp18",
+        "publication": "Kepp18",
         "bibcode": "2018A&A...617A..44K",
         "doi": "10.1051/0004-6361/201832957",
         "description": "Discovery of a planetary-mass companion within the gap of the transition disk around PDS 70"
     },
     {
-        "name": "Kirk93b",
+        "publication": "Kirk93b",
         "bibcode": "1993ApJ...406..701K",
         "doi": "10.1086/172480",
         "description": "The Unique Spectrum of the Brown Dwarf Candidate GD 165B and Comparison to the Spectra of Other Low-Luminosity Objects"
     },
     {
-        "name": "Kirk97b",
+        "publication": "Kirk97b",
         "bibcode": "1997AJ....113.1421K",
         "doi": "10.1086/118357",
         "description": "Ultra-Cool M Dwarfs Discovered by QSO Surveys.I: The APM Objects"
     },
     {
-        "name": "Knia13",
+        "publication": "Knia13",
         "bibcode": "2013ApJ...770..124K",
         "doi": "10.1088/0004-637X/770/2/124",
         "description": "Characterization of the nearby L/T Binary Brown Dwarf WISE J104915.57-531906.1 at 2 pc from the Sun"
     },
     {
-        "name": "Koen17",
+        "publication": "Koen17",
         "bibcode": "2017MNRAS.465.4723K",
         "doi": "10.1093/mnras/stw3106",
         "description": "Optical spectra of ultracool dwarfs with the Southern African Large Telescope"
     },
     {
-        "name": "Kohl12",
+        "publication": "Kohl12",
         "bibcode": "2012A&A...541A..29K",
         "doi": "10.1051/0004-6361/201118707",
         "description": "Orbits and masses in the multiple system LHS 1070"
     },
     {
-        "name": "Kopy14",
+        "publication": "Kopy14",
         "bibcode": "2014ApJ...797....3K",
         "doi": "10.1088/0004-637X/797/1/3",
         "description": "Deep z-band Observations of the Coolest Y Dwarf"
     },
     {
-        "name": "Kouw05",
+        "publication": "Kouw05",
         "bibcode": "2005A&A...430..137K",
         "doi": "10.1051/0004-6361:20048124",
         "description": "The primordial binary population.  I. A near-infrared adaptive optics search for close visual companions to A star members of Scorpius OB2"
     },
     {
-        "name": "Krau09a",
+        "publication": "Krau09a",
         "bibcode": "2009ApJ...703.1511K",
         "doi": "10.1088/0004-637X/703/2/1511",
         "description": "Unusually Wide Binaries: Are They Wide or Unusual?"
     },
     {
-        "name": "Krau12",
+        "publication": "Krau12",
         "bibcode": "2012ApJ...745....5K",
         "doi": "10.1088/0004-637X/745/1/5",
         "description": "LkCa 15: A Young Exoplanet Caught at Formation?"
     },
     {
-        "name": "Krau14a",
+        "publication": "Krau14a",
         "bibcode": "2014ApJ...781...20K",
         "doi": "10.1088/0004-637X/781/1/20",
         "description": "Three Wide Planetary-mass Companions to FW Tau, ROXs 12, and ROXs 42B"
     },
     {
-        "name": "Krau14b",
+        "publication": "Krau14b",
         "bibcode": "2014AJ....147..146K",
         "doi": "10.1088/0004-6256/147/6/146",
         "description": "A Stellar Census of the Tucana-Horologium Moving Group"
     },
     {
-        "name": "Kuzu11",
+        "publication": "Kuzu11",
         "bibcode": "2011AJ....141..119K",
         "doi": "10.1088/0004-6256/141/4/119",
         "description": "The Widest-separation Substellar Companion Candidate to a Binary T Tauri Star"
     },
     {
-        "name": "Kuzu13",
+        "publication": "Kuzu13",
         "bibcode": "2013ApJ...774...11K",
         "doi": "10.1088/0004-637X/774/1/11",
         "description": "Direct Imaging of a Cold Jovian Exoplanet in Orbit around the Sun-like Star GJ 504"
     },
     {
-        "name": "Lach15",
+        "publication": "Lach15",
         "bibcode": "2015ApJ...802...61L",
         "doi": "10.1088/0004-637X/802/1/61",
         "description": "Characterization of Low-mass, Wide-separation Substellar Companions to Stars in Upper Scorpius: Near-infrared Photometry and Spectroscopy"
     },
     {
-        "name": "Lafr08",
+        "publication": "Lafr08",
         "bibcode": "2008ApJ...689L.153L",
         "doi": "10.1086/595870",
         "description": "Direct Imaging and Spectroscopy of a Planetary-Mass Candidate Companion to a Young Solar Analog"
     },
     {
-        "name": "Lafr10",
+        "publication": "Lafr10",
         "bibcode": "2010ApJ...719..497L",
         "doi": "10.1088/0004-637X/719/1/497",
         "description": "The Directly Imaged Planet Around the Young Solar Analog 1RXS J160929.1 - 210524: Confirmation of Common Proper Motion, Temperature, and Mass"
     },
     {
-        "name": "Lafr11",
+        "publication": "Lafr11",
         "bibcode": "2011ApJ...730...42L",
         "doi": "10.1088/0004-637X/730/1/42",
         "description": "Discovery of an ~23 M <SUB>Jup</SUB> Brown Dwarf Orbiting ~700 AU from the Massive Star HIP 78530 in Upper Scorpius"
     },
     {
-        "name": "Lavi09",
+        "publication": "Lavi09",
         "bibcode": "2009ApJ...704.1098L",
         "doi": "10.1088/0004-637X/704/2/1098",
         "description": "Near-Infrared Observations of GQ Lup b Using the Gemini Integral Field Spectrograph NIFS"
     },
     {
-        "name": "Law_06",
+        "publication": "Law_06",
         "bibcode": "2006MNRAS.368.1917L",
         "doi": "10.1111/j.1365-2966.2006.10265.x",
         "description": "Discovery of five very low mass close binaries, resolved in the visible with lucky imaging<SUP>*</SUP>"
     },
     {
-        "name": "Lazo18",
+        "publication": "Lazo18",
         "bibcode": "2018A&A...618A.111L",
         "doi": "10.1051/0004-6361/201833626",
         "description": "Updated astrometry and masses of the LUH 16 brown dwarf binary"
     },
     {
-        "name": "Legg06",
+        "publication": "Legg06",
         "bibcode": "2006MNRAS.373..781L",
         "doi": "10.1111/j.1365-2966.2006.11069.x",
         "description": "JHK observations of faint standard stars in the Mauna Kea Observatories near-infrared photometric system"
     },
     {
-        "name": "Legg10b",
+        "publication": "Legg10b",
         "bibcode": "2010ApJ...720..252L",
         "doi": "10.1088/0004-637X/720/1/252",
         "description": "Properties of the T8.5 Dwarf Wolf 940 B"
     },
     {
-        "name": "Legg16",
+        "publication": "Legg16",
         "bibcode": "2016ApJ...824....2L",
         "doi": "10.3847/0004-637X/824/1/2",
         "description": "Near-infrared Spectroscopy of the Y0 WISEP J173835.52+273258.9 and the Y1 WISE J035000.32-565830.2: The Importance of Non-equilibrium Chemistry"
     },
     {
-        "name": "Legg19",
+        "publication": "Legg19",
         "bibcode": "2019ApJ...882..117L",
         "doi": "10.3847/1538-4357/ab3393",
         "description": "3.8 \u03bcm Imaging of 400-600 K Brown Dwarfs and Orbital Constraints for WISEP J045853.90+643452.6AB"
     },
     {
-        "name": "Legg96",
+        "publication": "Legg96",
         "bibcode": "1996ApJS..104..117L",
         "doi": "10.1086/192295",
         "description": "Infrared Spectra of Low-Mass Stars: Toward a Temperature Scale for Red Dwarfs"
     },
     {
-        "name": "Lepi02c",
+        "publication": "Lepi02c",
         "bibcode": "2002ApJ...581L..47L",
         "doi": "10.1086/345943",
         "description": "Discovery of an M8.5 Dwarf with Proper Motion \u03bc = 2.38\" per Year"
     },
     {
-        "name": "Lepi03d",
+        "publication": "Lepi03d",
         "bibcode": "2003AJ....126..921L",
         "doi": "10.1086/376745",
         "description": "New High Proper Motion Stars from the Digitized Sky Survey. II. Northern Stars with 0.5\" yr<SUP>-1</SUP> &lt; \u03bc &lt; 2.0\" yr<SUP>-1</SUP> at High Galactic Latitudes"
     },
     {
-        "name": "Lepi05c",
+        "publication": "Lepi05c",
         "bibcode": "2005AJ....130.1680L",
         "doi": "10.1086/432792",
         "description": "Nearby Stars from the LSPM-North Proper-Motion Catalog. I. Main-Sequence Dwarfs and Giants within 33 Parsecs of the Sun"
     },
     {
-        "name": "Lepi08a",
+        "publication": "Lepi08a",
         "bibcode": "2008AJ....135.2177L",
         "doi": "10.1088/0004-6256/135/6/2177",
         "description": "New High Proper Motion Stars from the Digitized Sky Survey. Iv. Completion of the Southern Survey and 170 Additional Stars with \u03bc &gt; 0.45'' yr<SUP> 1</SUP>"
     },
     {
-        "name": "Lepi11b",
+        "publication": "Lepi11b",
         "bibcode": "2011AJ....142..138L",
         "doi": "10.1088/0004-6256/142/4/138",
         "description": "An All-sky Catalog of Bright M Dwarfs"
     },
     {
-        "name": "Litt08",
+        "publication": "Litt08",
         "bibcode": "2008MNRAS.388.1582L",
         "doi": "10.1111/j.1365-2966.2008.13539.x",
         "description": "On the evolutionary status of short-period cataclysmic variables"
     },
     {
-        "name": "Litt13",
+        "publication": "Litt13",
         "bibcode": "2013MNRAS.431.2820L",
         "doi": "10.1093/mnras/stt378",
         "description": "A J-band detection of the sub-stellar mass donor in SDSS J1433+1011"
     },
     {
-        "name": "Litt14",
+        "publication": "Litt14",
         "bibcode": "2014MNRAS.445.2106L",
         "doi": "10.1093/mnras/stu1895",
         "description": "The substellar companion in the eclipsing white dwarf binary SDSS J141126.20+200911.1"
     },
     {
-        "name": "Liu_02a",
+        "publication": "Liu_02a",
         "bibcode": "2002ApJ...568L.107L",
         "doi": "10.1086/340375",
         "description": "Discovery of a Methane Dwarf from the IfA Deep Survey"
     },
     {
-        "name": "Liu_02b",
+        "publication": "Liu_02b",
         "bibcode": "2002ApJ...571..519L",
         "doi": "10.1086/339845",
         "description": "Crossing the Brown Dwarf Desert Using Adaptive Optics: A Very Close L Dwarf Companion to the Nearby Solar Analog HR 7672"
     },
     {
-        "name": "Liu_12",
+        "publication": "Liu_12",
         "bibcode": "2012ApJ...758...57L",
         "doi": "10.1088/0004-637X/758/1/57",
         "description": "Two Extraordinary Substellar Binaries at the T/Y Transition and the Y-band Fluxes of the Coolest Brown Dwarfs"
     },
     {
-        "name": "Liu_13a",
+        "publication": "Liu_13a",
         "bibcode": "2013AN....334...85L",
         "doi": "10.1002/asna.201211783",
         "description": "Infrared parallaxes of young field brown dwarfs and connections to directly imaged gas-giant exoplanets"
     },
     {
-        "name": "Liu_16",
+        "publication": "Liu_16",
         "bibcode": "2016ApJ...833...96L",
         "doi": "10.3847/1538-4357/833/1/96",
         "description": "The Hawaii Infrared Parallax Program. II. Young Ultracool Field Dwarfs"
     },
     {
-        "name": "Lloy06",
+        "publication": "Lloy06",
         "bibcode": "2006ApJ...650L.131L",
         "doi": "10.1086/508771",
         "description": "Direct Detection of the Brown Dwarf GJ 802B with Adaptive Optics Masking Interferometry"
     },
     {
-        "name": "Lodi06b",
+        "publication": "Lodi06b",
         "bibcode": "2006MNRAS.373...95L",
         "doi": "10.1111/j.1365-2966.2006.10958.x",
         "description": "New members in the Upper Scorpius association from the UKIRT Infrared Deep Sky Survey Early Data Release\u2020"
     },
     {
-        "name": "Lodi08",
+        "publication": "Lodi08",
         "bibcode": "2008MNRAS.383.1385L",
         "doi": "10.1111/j.1365-2966.2007.12676.x",
         "description": "Near-infrared cross-dispersed spectroscopy of brown dwarf candidates in the UpperSco association"
     },
     {
-        "name": "Lodi09b",
+        "publication": "Lodi09b",
         "bibcode": "2009MNRAS.395.1631L",
         "doi": "10.1111/j.1365-2966.2009.14650.x",
         "description": "Two distant brown dwarfs in the UKIRT Infrared Deep Sky Survey Deep Extragalactic Survey Data Release 2"
     },
     {
-        "name": "Lodi09d",
+        "publication": "Lodi09d",
         "bibcode": "2009MNRAS.397..258L",
         "doi": "10.1111/j.1365-2966.2008.14384.x",
         "description": "Identifying nearby field T dwarfs in the UKIDSS Galactic Clusters Survey"
     },
     {
-        "name": "Lodi10",
+        "publication": "Lodi10",
         "bibcode": "2010ApJ...708L.107L",
         "doi": "10.1088/2041-8205/708/2/L107",
         "description": "GTC/OSIRIS Spectroscopic Identification of a Faint L Subdwarf in the UKIRT Infrared Deep Sky Survey"
     },
     {
-        "name": "Lodi12a",
+        "publication": "Lodi12a",
         "bibcode": "2012MNRAS.422.1495L",
         "doi": "10.1111/j.1365-2966.2012.20723.x",
         "description": "Astrometric and photometric initial mass functions from the UKIDSS Galactic Clusters Survey - I. The Pleiades"
     },
     {
-        "name": "Lodi12b",
+        "publication": "Lodi12b",
         "bibcode": "2012A&A...542A.105L",
         "doi": "10.1051/0004-6361/201118717",
         "description": "New ultracool subdwarfs identified in large-scale surveys using Virtual Observatory tools. I. UKIDSS LAS DR5 vs. SDSS DR7"
     },
     {
-        "name": "Lodi12d",
+        "publication": "Lodi12d",
         "bibcode": "2012A&A...548A..53L",
         "doi": "10.1051/0004-6361/201220182",
         "description": "First T dwarfs in the VISTA Hemisphere Survey"
     },
     {
-        "name": "Lodi13a",
+        "publication": "Lodi13a",
         "bibcode": "2013MNRAS.435.2474L",
         "doi": "10.1093/mnras/stt1460",
         "description": "Probing the Upper Scorpius mass function in the planetary-mass regime"
     },
     {
-        "name": "Lodi13c",
+        "publication": "Lodi13c",
         "bibcode": "2013MNRAS.431.3222L",
         "doi": "10.1093/mnras/stt402",
         "description": "Astrometric and photometric initial mass functions from the UKIDSS Galactic Clusters Survey - IV. Upper Sco\u2605"
     },
     {
-        "name": "Lodi14a",
+        "publication": "Lodi14a",
         "bibcode": "2014A&A...569A.120L",
         "doi": "10.1051/0004-6361/201424210",
         "description": "Binary frequency of planet-host stars at wide separations. A new brown dwarf companion to a planet-host star"
     },
     {
-        "name": "Lodi14b",
+        "publication": "Lodi14b",
         "bibcode": "2014MNRAS.445.3908L",
         "doi": "10.1093/mnras/stu2059",
         "description": "Spectroscopy of Hyades L dwarf candidates<SUP>\u2605</SUP>"
     },
     {
-        "name": "Lodi18",
+        "publication": "Lodi18",
         "bibcode": "2018MNRAS.473.2020L",
         "doi": "10.1093/mnras/stx2279",
         "description": "The optical + infrared L dwarf spectral sequence of young planetary-mass objects in the Upper Scorpius association"
     },
     {
-        "name": "Loop11",
+        "publication": "Loop11",
         "bibcode": "2011PhDT.......245L",
         "doi": null,
         "description": "New Nearby Accreting Young Stars and a First Estimate of the IMF for the TW Hydrae Association"
     },
     {
-        "name": "Luca12",
+        "publication": "Luca12",
         "bibcode": "2012yCat.2316....0U",
         "doi": null,
         "description": "VizieR Online Data Catalog: UKIDSS-DR6 Galactic Plane Survey (Lucas+ 2012)"
     },
     {
-        "name": "Luhm04c",
+        "publication": "Luhm04c",
         "bibcode": "2004ApJ...614..398L",
         "doi": "10.1086/423666",
         "description": "The First Discovery of a Wide Binary Brown Dwarf"
     },
     {
-        "name": "Luhm06b",
+        "publication": "Luhm06b",
         "bibcode": "2006ApJ...645..676L",
         "doi": "10.1086/504073",
         "description": "The Spatial Distribution of Brown Dwarfs in Taurus"
     },
     {
-        "name": "Luhm06d",
+        "publication": "Luhm06d",
         "bibcode": "2006ApJ...649..894L",
         "doi": "10.1086/506517",
         "description": "Discovery of a Young Substellar Companion in Chamaeleon"
     },
     {
-        "name": "Luhm07d",
+        "publication": "Luhm07d",
         "bibcode": "2007ApJS..173..104L",
         "doi": "10.1086/520114",
         "description": "The Stellar Population of the Chamaeleon I Star-forming Region"
     },
     {
-        "name": "Luhm10",
+        "publication": "Luhm10",
         "bibcode": "2010ApJS..186..111L",
         "doi": "10.1088/0067-0049/186/1/111",
         "description": "The Disk Population of the Taurus Star-Forming Region"
     },
     {
-        "name": "Luhm12d",
+        "publication": "Luhm12d",
         "bibcode": "2012ApJ...760..152L",
         "doi": "10.1088/0004-637X/760/2/152",
         "description": "New M, L, and T Dwarf Companions to Nearby Stars from the Wide-field Infrared Survey Explorer"
     },
     {
-        "name": "Luhm14a",
+        "publication": "Luhm14a",
         "bibcode": "2014ApJ...781....4L",
         "doi": "10.1088/0004-637X/781/1/4",
         "description": "A Search for a Distant Companion to the Sun with the Wide-field Infrared Survey Explorer"
     },
     {
-        "name": "Luhm14c",
+        "publication": "Luhm14c",
         "bibcode": "2014ApJ...787..126L",
         "doi": "10.1088/0004-637X/787/2/126",
         "description": "Characterization of High Proper Motion Objects from the Wide-field Infrared Survey Explorer"
     },
     {
-        "name": "Luhm14e",
+        "publication": "Luhm14e",
         "bibcode": "2014ApJ...796....6L",
         "doi": "10.1088/0004-637X/796/1/6",
         "description": "A New Parallax Measurement for the Coldest Known Brown Dwarf"
     },
     {
-        "name": "Luhm16b",
+        "publication": "Luhm16b",
         "bibcode": "2016ApJ...827...52L",
         "doi": "10.3847/0004-637X/827/1/52",
         "description": "A Census of Young Stars and Brown Dwarfs in IC 348 and NGC 1333"
     },
     {
-        "name": "Luyt49b",
+        "publication": "Luyt49b",
         "bibcode": "1949ApJ...109..532L",
         "doi": "10.1086/145158",
         "description": "A New Star of Large Proper Motion (L 726-8)."
     },
     {
-        "name": "Luyt57a",
+        "publication": "Luyt57a",
         "bibcode": "1957cnes.book.....L",
         "doi": null,
         "description": "A catalogue of 9867 stars in the Southern Hemisphere with proper motions exceeding 0.\"2 annually."
     },
     {
-        "name": "Mace13b",
+        "publication": "Mace13b",
         "bibcode": "2013ApJ...777...36M",
         "doi": "10.1088/0004-637X/777/1/36",
         "description": "The Exemplar T8 Subdwarf Companion of Wolf 1130"
     },
     {
-        "name": "Mair16",
+        "publication": "Mair16",
         "bibcode": "2016A&A...587A..56M",
         "doi": "10.1051/0004-6361/201526594",
         "description": "First light of the VLT planet finder SPHERE. II. The physical properties and the architecture of the young systems PZ Telescopii and HD 1160 revisited"
     },
     {
-        "name": "Mama18",
+        "publication": "Mama18",
         "bibcode": "2018RNAAS...2..205M",
         "doi": "10.3847/2515-5172/aaed3c",
         "description": "WISE J064336.71-022315.4: A Thick-disk L8 Brown Dwarf Discovered by Gaia DR2 at 13.9 pc"
     },
     {
-        "name": "Manj13",
+        "publication": "Manj13",
         "bibcode": "2013A&A...560A..52M",
         "doi": "10.1051/0004-6361/201321720",
         "description": "Parallax measurements of cool brown dwarfs"
     },
     {
-        "name": "Manj16",
+        "publication": "Manj16",
         "bibcode": "2016MNRAS.455.1341M",
         "doi": "10.1093/mnras/stv2048",
         "description": "Hunting for brown dwarf binaries and testing atmospheric models with X-Shooter"
     },
     {
-        "name": "Mann19",
+        "publication": "Mann19",
         "bibcode": "2019ApJ...871...63M",
         "doi": "10.3847/1538-4357/aaf3bc",
         "description": "How to Constrain Your M Dwarf. II. The Mass-Luminosity-Metallicity Relation from 0.075 to 0.70 Solar Masses"
     },
     {
-        "name": "Maro07",
+        "publication": "Maro07",
         "bibcode": "2007ApJ...654L.151M",
         "doi": "10.1086/511071",
         "description": "GQ Lup B Visible and Near-Infrared Photometric Analysis"
     },
     {
-        "name": "Maro14",
+        "publication": "Maro14",
         "bibcode": "2014MNRAS.439..372M",
         "doi": "10.1093/mnras/stt2463",
         "description": "The extremely red L dwarf ULAS J222711-004547 - dominated by dust"
     },
     {
-        "name": "Maro15",
+        "publication": "Maro15",
         "bibcode": "2015MNRAS.449.3651M",
         "doi": "10.1093/mnras/stv530",
         "description": "A large spectroscopic sample of L and T dwarfs from UKIDSS LAS: peculiar objects, binaries, and space density"
     },
     {
-        "name": "Maro17",
+        "publication": "Maro17",
         "bibcode": "2017MNRAS.470.4885M",
         "doi": "10.1093/mnras/stx1500",
         "description": "Ultracool dwarf benchmarks with Gaia primaries"
     },
     {
-        "name": "Mars08",
+        "publication": "Mars08",
         "bibcode": "2008AJ....135.1000M",
         "doi": "10.1088/0004-6256/135/3/1000",
         "description": "Finding Extreme Subdwarfs"
     },
     {
-        "name": "Mart00b",
+        "publication": "Mart00b",
         "bibcode": "2000AJ....120.2114M",
         "doi": "10.1086/301559",
         "description": "Spectroscopy of Very Low Luminosity Young Stellar Objects in Taurus"
     },
     {
-        "name": "Mart00c",
+        "publication": "Mart00c",
         "bibcode": "2000ApJ...543..299M",
         "doi": "10.1086/317089",
         "description": "Membership and Multiplicity among Very Low Mass Stars and Brown Dwarfs in the Pleiades Cluster"
     },
     {
-        "name": "Mart10",
+        "publication": "Mart10",
         "bibcode": "2010A&A...517A..53M",
         "doi": "10.1051/0004-6361/201014202",
         "description": "Spectroscopic characterization of 78 DENIS ultracool dwarf candidates in the solar neighborhood and the Upper Scorpii OB association"
     },
     {
-        "name": "Mart94",
+        "publication": "Mart94",
         "bibcode": "1994ApJ...436..262M",
         "doi": "10.1086/174900",
         "description": "Constraints to the Masses of Brown Dwarf Candidates from the Lithium Test"
     },
     {
-        "name": "Mart98c",
+        "publication": "Mart98c",
         "bibcode": "1998ApJ...507L..41M",
         "doi": "10.1086/311675",
         "description": "The First L-Type Brown Dwarf in the Pleiades"
     },
     {
-        "name": "Mart99d",
+        "publication": "Mart99d",
         "bibcode": "1999AJ....118.1005M",
         "doi": "10.1086/300983",
         "description": "The Lithium Test in Young Brown Dwarf Candidates"
     },
     {
-        "name": "Mast12a",
+        "publication": "Mast12a",
         "bibcode": "2012ApJ...752L..14M",
         "doi": "10.1088/2041-8205/752/1/L14",
         "description": "Discovery of Three Distant, Cold Brown Dwarfs in the WFC3 Infrared Spectroscopic Parallels Survey"
     },
     {
-        "name": "Mats11b",
+        "publication": "Mats11b",
         "bibcode": "2011AJ....142...64M",
         "doi": "10.1088/0004-6256/142/2/64",
         "description": "1 \u03bcm Excess Sources in the UKIDSS. I. Three T Dwarfs in the Sloan Digital Sky Survey Southern Equatorial Stripe"
     },
     {
-        "name": "Mats19",
+        "publication": "Mats19",
         "bibcode": "2019ApJ...883..183M",
         "doi": "10.3847/1538-4357/ab3c60",
         "description": "Subaru High-z Exploration of Low-luminosity Quasars (SHELLQs). X. Discovery of 35 Quasars and Luminous Galaxies at 5.7 \u2264 z \u2264 7.0"
     },
     {
-        "name": "McCa02",
+        "publication": "McCa02",
         "bibcode": "2002A&A...390L..27M",
         "doi": "10.1051/0004-6361:20020928",
         "description": "Search for nearby stars among proper motion stars selected by optical-to-infrared photometry. II. Two late M dwarfs within 10 pc"
     },
     {
-        "name": "McCa64c",
+        "publication": "McCa64c",
         "bibcode": "1964RA......6..571M",
         "doi": null,
         "description": "M stars in the region of the south galactic pole"
     },
     {
-        "name": "McCr10",
+        "publication": "McCr10",
         "bibcode": "2010ApJ...708..202M",
         "doi": "10.1088/0004-637X/708/1/202",
         "description": "The COSMOS-WIRCam Near-Infrared Imaging Survey. I. BzK-Selected Passive and Star-Forming Galaxy Candidates at z gsim 1.4"
     },
     {
-        "name": "McEl07",
+        "publication": "McEl07",
         "bibcode": "2007ApJ...656..505M",
         "doi": "10.1086/510063",
         "description": "First High-Contrast Science with an Integral Field Spectrograph: The Substellar Companion to GQ Lupi"
     },
     {
-        "name": "McGo04",
+        "publication": "McGo04",
         "bibcode": "2004ApJ...600.1020M",
         "doi": "10.1086/379849",
         "description": "Identifying Young Brown Dwarfs Using Gravity-Sensitive Spectral Features"
     },
     {
-        "name": "McLe07",
+        "publication": "McLe07",
         "bibcode": "2007ApJ...658.1217M",
         "doi": "10.1086/511740",
         "description": "The NIRSPEC Brown Dwarf Spectroscopic Survey. II. High-Resolution J-Band Spectra of M, L, and T Dwarfs"
     },
     {
-        "name": "McMa13",
+        "publication": "McMa13",
         "bibcode": "2013Msngr.154...35M",
         "doi": null,
         "description": "First Scientific Results from the VISTA Hemisphere Survey (VHS)"
     },
     {
-        "name": "Mena02",
+        "publication": "Mena02",
         "bibcode": "2002A&A...396L..35M",
         "doi": "10.1051/0004-6361:20021657",
         "description": "Optical linear polarimetry of ultra cool dwarfs"
     },
     {
-        "name": "Mesa19",
+        "publication": "Mesa19",
         "bibcode": "2019A&A...632A..25M",
         "doi": "10.1051/0004-6361/201936764",
         "description": "VLT/SPHERE exploration of the young multiplanetary system PDS70"
     },
     {
-        "name": "Mesa20",
+        "publication": "Mesa20",
         "bibcode": "2020MNRAS.495.4279M",
         "doi": "10.1093/mnras/staa1444",
         "description": "Characterizing brown dwarf companions with IRDIS long-slit spectroscopy: HD 1160 B and HD 19467 B"
     },
     {
-        "name": "Mesh15b",
+        "publication": "Mesh15b",
         "bibcode": "2015MNRAS.453.2378M",
         "doi": "10.1093/mnras/stv1732",
         "description": "Discovery of a low-mass companion to the F7V star HD 984"
     },
     {
-        "name": "Meto15",
+        "publication": "Meto15",
         "bibcode": "2015MNRAS.446.3878M",
         "doi": "10.1093/mnras/stu2370",
         "description": "Low-resolution optical spectra of ultracool dwarfs with OSIRIS/GTC"
     },
     {
-        "name": "Mile17",
+        "publication": "Mile17",
         "bibcode": "2017AJ....154..262M",
         "doi": "10.3847/1538-3881/aa9711",
         "description": "The Prototypical Young L/T-Transition Dwarf HD 203030B Likely Has Planetary Mass"
     },
     {
-        "name": "Minn17",
+        "publication": "Minn17",
         "bibcode": "2017yCat.2348....0M",
         "doi": null,
         "description": "VizieR Online Data Catalog: VISTA Variable in the Via Lactea Survey DR2 (Minniti+, 2017)"
     },
     {
-        "name": "Moha03a",
+        "publication": "Moha03a",
         "bibcode": "2003ApJ...583..451M",
         "doi": "10.1086/345097",
         "description": "Rotation and Activity in Mid-M to L Field Dwarfs"
     },
     {
-        "name": "Mone83",
+        "publication": "Mone83",
         "bibcode": "1983AJ.....88.1489M",
         "doi": "10.1086/113438",
         "description": "CCD astrometry. I. Preliminary results from the KPNO 4-m/CCD parallaxprogram."
     },
     {
-        "name": "Mugr10",
+        "publication": "Mugr10",
         "bibcode": "2010A&A...523L...1M",
         "doi": "10.1051/0004-6361/201015523",
         "description": "Direct detection of a substellar companion to the young nearby star PZ Telescopii"
     },
     {
-        "name": "Mull18",
+        "publication": "Mull18",
         "bibcode": "2018A&A...617L...2M",
         "doi": "10.1051/0004-6361/201833584",
         "description": "Orbital and atmospheric characterization of the planet within the gap of the PDS 70 transition disk"
     },
     {
-        "name": "Murp15b",
+        "publication": "Murp15b",
         "bibcode": "2015MNRAS.453.2220M",
         "doi": "10.1093/mnras/stv1745",
         "description": "New members of the TW Hydrae Association and two accreting M-dwarfs in Scorpius-Centaurus"
     },
     {
-        "name": "Muzi12b",
+        "publication": "Muzi12b",
         "bibcode": "2012AJ....144..180M",
         "doi": "10.1088/0004-6256/144/6/180",
         "description": "Discovery of Two Very Wide Binaries with Ultracool Companions and a New Brown Dwarf at the L/T Transition"
     },
     {
-        "name": "Muzi15",
+        "publication": "Muzi15",
         "bibcode": "2015ApJ...810..159M",
         "doi": "10.1088/0004-637X/810/2/159",
         "description": "Substellar Objects in Nearby Young Clusters (SONYC) IX: The Planetary-Mass Domain of Chamaeleon-I and Updated Mass Function in Lupus-3"
     },
     {
-        "name": "Neuh00b",
+        "publication": "Neuh00b",
         "bibcode": "2000A&A...360L..39N",
         "doi": null,
         "description": "Spectrum and proper motion of a brown dwarf companion of the T Tauri star CoD-33<SUP>\u0302</SUP>7795"
     },
     {
-        "name": "Neuh03d",
+        "publication": "Neuh03d",
         "bibcode": "2003AN....324..535N",
         "doi": "10.1002/asna.200310167",
         "description": "An infrared imaging search for low-mass companions to members of the young nearby \u03b2 Pic and Tucana/Horologium associations"
     },
     {
-        "name": "Neuh04a",
+        "publication": "Neuh04a",
         "bibcode": "2004A&A...420..647N",
         "doi": "10.1051/0004-6361:20035713",
         "description": "Infrared spectroscopy of a brown dwarf companion candidate near the young star GSC 08047-00232 in Horologium"
     },
     {
-        "name": "Neuh05a",
+        "publication": "Neuh05a",
         "bibcode": "2005A&A...435L..13N",
         "doi": "10.1051/0004-6361:200500104",
         "description": "Evidence for a co-moving sub-stellar companion of GQ Lup"
     },
     {
-        "name": "Neuh11",
+        "publication": "Neuh11",
         "bibcode": "2011MNRAS.416.1430N",
         "doi": "10.1111/j.1365-2966.2011.19139.x",
         "description": "Further deep imaging of HR 7329 A (\u03b7 Tel A) and its brown dwarf companion B"
     },
     {
-        "name": "Newt14",
+        "publication": "Newt14",
         "bibcode": "2014AJ....147...20N",
         "doi": "10.1088/0004-6256/147/1/20",
         "description": "Near-infrared Metallicities, Radial Velocities, and Spectral Types for 447 Nearby M Dwarfs"
     },
     {
-        "name": "Niel13",
+        "publication": "Niel13",
         "bibcode": "2013ApJ...776....4N",
         "doi": "10.1088/0004-637X/776/1/4",
         "description": "The Gemini NICI Planet-Finding Campaign: The Frequency of Giant Planets around Young B and A Stars"
     },
     {
-        "name": "Opit16",
+        "publication": "Opit16",
         "bibcode": "2016ApJ...819...17O",
         "doi": "10.3847/0004-637X/819/1/17",
         "description": "Searching for Binary Y Dwarfs with the Gemini Multi-conjugate Adaptive Optics System (GeMS)"
     },
     {
-        "name": "Pena11",
+        "publication": "Pena11",
         "bibcode": "2011IAUS..276..489R",
         "doi": "10.1017/S1743921311020928",
         "description": "Search and characterization of T-type planetary mass candidates in the \u03c3 Orionis cluster"
     },
     {
-        "name": "Pena12",
+        "publication": "Pena12",
         "bibcode": "2012ApJ...754...30P",
         "doi": "10.1088/0004-637X/754/1/30",
         "description": "New Isolated Planetary-mass Objects and the Stellar and Substellar Mass Function of the \u03c3 Orionis Cluster"
     },
     {
-        "name": "Pena15",
+        "publication": "Pena15",
         "bibcode": "2015A&A...574A.118P",
         "doi": "10.1051/0004-6361/201424816",
         "description": "Characterization of the known T-type dwarfs towards the \u03c3 Orionis cluster"
     },
     {
-        "name": "Pena16",
+        "publication": "Pena16",
         "bibcode": "2016A&A...586A.157P",
         "doi": "10.1051/0004-6361/201527425",
         "description": "A new free-floating planet in the Upper Scorpius association"
     },
     {
-        "name": "Pere14",
+        "publication": "Pere14",
         "bibcode": "2014A&A...567A...6P",
         "doi": "10.1051/0004-6361/201423615",
         "description": "2MASS J154043.42-510135.7: a new addition to the 5 pc population"
     },
     {
-        "name": "Phan11b",
+        "publication": "Phan11b",
         "bibcode": "2011AN....332..668P",
         "doi": "10.1002/asna.201111574",
         "description": "Maximum Reduced Proper Motion method: Detection of new nearby ultracool dwarfs"
     },
     {
-        "name": "Pine16",
+        "publication": "Pine16",
         "bibcode": "2016ApJ...826...73P",
         "doi": "10.3847/0004-637X/826/1/73",
         "description": "A Survey for H\u03b1 Emission from Late L Dwarfs and T Dwarfs"
     },
     {
-        "name": "Pinf14a",
+        "publication": "Pinf14a",
         "bibcode": "2014MNRAS.437.1009P",
         "doi": "10.1093/mnras/stt1437",
         "description": "A deep WISE search for very late type objects and the discovery of two halo/thick-disc T dwarfs: WISE 0013+0634 and WISE 0833+0052"
     },
     {
-        "name": "Poko03",
+        "publication": "Poko03",
         "bibcode": "2003A&A...397..575P",
         "doi": "10.1051/0004-6361:20021385",
         "description": "The Liverpool-Edinburgh high proper motion survey"
     },
     {
-        "name": "Pope13",
+        "publication": "Pope13",
         "bibcode": "2013ApJ...767..110P",
         "doi": "10.1088/0004-637X/767/2/110",
         "description": "Dancing in the Dark: New Brown Dwarf Binaries from Kernel Phase Interferometry"
     },
     {
-        "name": "Qi__15",
+        "publication": "Qi__15",
         "bibcode": "2015AJ....150..137Q",
         "doi": "10.1088/0004-6256/150/4/137",
         "description": "Absolute Proper Motions Outside the Plane (APOP)&amp;mdashA Step Toward the GSC2.4"
     },
     {
-        "name": "Radi12",
+        "publication": "Radi12",
         "bibcode": "2012ApJ...750..105R",
         "doi": "10.1088/0004-637X/750/2/105",
         "description": "Large-amplitude Variations of an L/T Transition Brown Dwarf: Multi-wavelength Observations of Patchy, High-contrast Cloud Features"
     },
     {
-        "name": "Radi13",
+        "publication": "Radi13",
         "bibcode": "2013ApJ...778...36R",
         "doi": "10.1088/0004-637X/778/1/36",
         "description": "Discovery of a Visual T-dwarf Triple System and Binarity at the L/T Transition"
     },
     {
-        "name": "Raja17",
+        "publication": "Raja17",
         "bibcode": "2017AJ....154...10R",
         "doi": "10.3847/1538-3881/aa74db",
         "description": "Characterizing 51 Eri b from 1 to 5 \u03bcm: A Partly Cloudy Exoplanet"
     },
     {
-        "name": "Rajp12",
+        "publication": "Rajp12",
         "bibcode": "2012A&A...545A..85R",
         "doi": "10.1051/0004-6361/201219029",
         "description": "The very low mass multiple system LHS 1070. A testbed for model atmospheres for the lower end of the main sequence"
     },
     {
-        "name": "Rame13a",
+        "publication": "Rame13a",
         "bibcode": "2013ApJ...772L..15R",
         "doi": "10.1088/2041-8205/772/2/L15",
         "description": "Discovery of a Probable 4-5 Jupiter-mass Exoplanet to HD 95086 by Direct Imaging"
     },
     {
-        "name": "Rams15b",
+        "publication": "Rams15b",
         "bibcode": "2015MNRAS.453.1484R",
         "doi": "10.1093/mnras/stv1742",
         "description": "Searching for I-band variability in stars in the M/L spectral transition region"
     },
     {
-        "name": "Reid03b",
+        "publication": "Reid03b",
         "bibcode": "2003AJ....126.2449R",
         "doi": "10.1086/378907",
         "description": "Meeting the Cool Neighbors. VI. A Search for Nearby Ultracool Dwarfs in the Galactic Plane"
     },
     {
-        "name": "Reid07",
+        "publication": "Reid07",
         "bibcode": "2007AJ....133.2825R",
         "doi": "10.1086/517914",
         "description": "Meeting the Cool Neighbors. XI. Beyond the NLTT Catalog"
     },
     {
-        "name": "Reid81",
+        "publication": "Reid81",
         "bibcode": "1981MNRAS.196P..15R",
         "doi": "10.1093/mnras/196.1.15P",
         "description": "A star of very low luminosity."
     },
     {
-        "name": "Rein09f",
+        "publication": "Rein09f",
         "bibcode": "2009ApJ...705.1416R",
         "doi": "10.1088/0004-637X/705/2/1416",
         "description": "A Volume-Limited Sample of 63 M7-M9.5 Dwarfs. I. Space Motion, Kinematic Age, and Lithium"
     },
     {
-        "name": "Rein10c",
+        "publication": "Rein10c",
         "bibcode": "2010A&A...513L...9R",
         "doi": "10.1051/0004-6361/201014206",
         "description": "Discovery of a nearby young brown dwarf binary candidate"
     },
     {
-        "name": "Reyl06",
+        "publication": "Reyl06",
         "bibcode": "2006MNRAS.373..705R",
         "doi": "10.1111/j.1365-2966.2006.11051.x",
         "description": "Optical spectroscopy of high proper motion stars: new M dwarfs within 10 pc and the closest pair of subdwarfs"
     },
     {
-        "name": "Reyl14",
+        "publication": "Reyl14",
         "bibcode": "2014A&A...561A..66R",
         "doi": "10.1051/0004-6361/201322107",
         "description": "CFBDS J111807-064016: A new L/T transition brown dwarf in a binary system"
     },
     {
-        "name": "Reyl18",
+        "publication": "Reyl18",
         "bibcode": "2018A&A...619L...8R",
         "doi": "10.1051/0004-6361/201834082",
         "description": "New ultra-cool and brown dwarf candidates in Gaia DR2"
     },
     {
-        "name": "Riaz06b",
+        "publication": "Riaz06b",
         "bibcode": "2006AJ....132..866R",
         "doi": "10.1086/505632",
         "description": "Identification of New M Dwarfs in the Solar Neighborhood"
     },
     {
-        "name": "Ried14",
+        "publication": "Ried14",
         "bibcode": "2014AJ....147...85R",
         "doi": "10.1088/0004-6256/147/4/85",
         "description": "The Solar Neighborhood. XXXIII. Parallax Results from the CTIOPI 0.9 m Program: Trigonometric Parallaxes of Nearby Low-mass Active and Young Systems"
     },
     {
-        "name": "Robe16",
+        "publication": "Robe16",
         "bibcode": "2016ApJ...830..144R",
         "doi": "10.3847/0004-637X/830/2/144",
         "description": "A Brown Dwarf Census from the SIMP Survey"
     },
     {
-        "name": "Rode18",
+        "publication": "Rode18",
         "bibcode": "2018A&A...618A..23R",
         "doi": "10.1051/0004-6361/201832924",
         "description": "Dynamical masses of M-dwarf binaries in young moving groups. I. The case of TWA 22 and GJ 2060"
     },
     {
-        "name": "Rodo80",
+        "publication": "Rodo80",
         "bibcode": "1980AJ.....85..298R",
         "doi": "10.1086/112674",
         "description": "G 208- 44/45 : another double flare star ?"
     },
     {
-        "name": "Rodr13",
+        "publication": "Rodr13",
         "bibcode": "2013ApJ...774..101R",
         "doi": "10.1088/0004-637X/774/2/101",
         "description": "The GALEX Nearby Young-Star Survey"
     },
     {
-        "name": "Ross26",
+        "publication": "Ross26",
         "bibcode": "1926AJ.....36..124R",
         "doi": "10.1086/104699",
         "description": "New proper-motion stars, (second list)"
     },
     {
-        "name": "Rout12",
+        "publication": "Rout12",
         "bibcode": "2012ApJ...747L..22R",
         "doi": "10.1088/2041-8205/747/2/L22",
         "description": "The Arecibo Detection of the Coolest Radio-flaring Brown Dwarf"
     },
     {
-        "name": "Sahl13",
+        "publication": "Sahl13",
         "bibcode": "2013A&A...556A.133S",
         "doi": "10.1051/0004-6361/201321871",
         "description": "Astrometric orbit of a low-mass companion to an ultracool dwarf"
     },
     {
-        "name": "Sahl14",
+        "publication": "Sahl14",
         "bibcode": "2014A&A...565A..20S",
         "doi": "10.1051/0004-6361/201323208",
         "description": "Astrometric planet search around southern ultracool dwarfs. I. First results, including parallaxes of 20 M8-L2 dwarfs"
     },
     {
-        "name": "Sahl15b",
+        "publication": "Sahl15b",
         "bibcode": "2015A&A...577A..15S",
         "doi": "10.1051/0004-6361/201525757",
         "description": "Astrometric planet search around southern ultracool dwarfs. III. Discovery of a brown dwarf in a 3-year orbit around DE0630-18"
     },
     {
-        "name": "Sahl15c",
+        "publication": "Sahl15c",
         "bibcode": "2015A&A...579A..61S",
         "doi": "10.1051/0004-6361/201425536",
         "description": "DE0823-49 is a juvenile binary brown dwarf at 20.7 pc"
     },
     {
-        "name": "Sahl15d",
+        "publication": "Sahl15d",
         "bibcode": "2015MNRAS.453L.103S",
         "doi": "10.1093/mnrasl/slv113",
         "description": "Mass ratio of the 2 pc binary brown dwarf LUH 16 and limits on planetary companions from astrometry"
     },
     {
-        "name": "Sahl20",
+        "publication": "Sahl20",
         "bibcode": "2020MNRAS.495.1136S",
         "doi": "10.1093/mnras/staa1235",
         "description": "Astrometric orbits of spectral binary brown dwarfs - I. Massive T dwarf companions to 2M1059-21 and 2M0805+48"
     },
     {
-        "name": "Sali03a",
+        "publication": "Sali03a",
         "bibcode": "2003ApJ...582.1011S",
         "doi": "10.1086/344822",
         "description": "Improved Astrometry and Photometry for the Luyten Catalog. II. Faint Stars and the Revised Catalog"
     },
     {
-        "name": "Sall15",
+        "publication": "Sall15",
         "bibcode": "2015Natur.527..342S",
         "doi": "10.1038/nature15761",
         "description": "Accreting protoplanets in the LkCa 15 transition disk"
     },
     {
-        "name": "Sant18",
+        "publication": "Sant18",
         "bibcode": "2018MNRAS.475.2994S",
         "doi": "10.1093/mnras/stx3325",
         "description": "Accretion signatures in the X-shooter spectrum of the substellar companion to SR12"
     },
     {
-        "name": "Sarr14",
+        "publication": "Sarr14",
         "bibcode": "2014A&A...563A..45S",
         "doi": "10.1051/0004-6361/201322413",
         "description": "Cluster membership probabilities from proper motions and multi-wavelength photometric catalogues. I. Method and application to the Pleiades cluster"
     },
     {
-        "name": "Schl14",
+        "publication": "Schl14",
         "bibcode": "2014ApJ...783...27S",
         "doi": "10.1088/0004-637X/783/1/27",
         "description": "Characterization of the Benchmark Binary NLTT 33370"
     },
     {
-        "name": "Schm08b",
+        "publication": "Schm08b",
         "bibcode": "2008A&A...491..311S",
         "doi": "10.1051/0004-6361:20078840",
         "description": "Direct evidence of a sub-stellar companion around CT Chamaeleontis"
     },
     {
-        "name": "Schm15",
+        "publication": "Schm15",
         "bibcode": "2015AJ....149..158S",
         "doi": "10.1088/0004-6256/149/5/158",
         "description": "BOSS Ultracool Dwarfs. I. Colors and Magnetic Activity of M and L Dwarfs"
     },
     {
-        "name": "Schn12a",
+        "publication": "Schn12a",
         "bibcode": "2012ApJ...754...39S",
         "doi": "10.1088/0004-637X/754/1/39",
         "description": "TW HYA Association Membership and New WISE-detected Circumstellar Disks"
     },
     {
-        "name": "Schn16a",
+        "publication": "Schn16a",
         "bibcode": "2016ApJ...817..112S",
         "doi": "10.3847/0004-637X/817/2/112",
         "description": "A Proper Motion Survey Using the First Sky Pass of NEOWISE-reactivation Data"
     },
     {
-        "name": "Schn16c",
+        "publication": "Schn16c",
         "bibcode": "2016ApJ...823L..35S",
         "doi": "10.3847/2041-8205/823/2/L35",
         "description": "The Collapse of the Wien Tail in the Coldest Brown Dwarf? Hubble Space Telescope Near-infrared Photometry of WISE J085510.83-071442.5"
     },
     {
-        "name": "Schn17",
+        "publication": "Schn17",
         "bibcode": "2017AJ....153..196S",
         "doi": "10.3847/1538-3881/aa6624",
         "description": "A 2MASS/AllWISE Search for Extremely Red L Dwarfs: The Discovery of Several Likely L Type Members of \u03b2 Pic, AB Dor, Tuc-Hor, Argus, and the Hyades"
     },
     {
-        "name": "Scho00",
+        "publication": "Scho00",
         "bibcode": "2000A&A...353..958S",
         "doi": null,
         "description": "New high-proper motion survey in the Southern sky"
     },
     {
-        "name": "Scho01",
+        "publication": "Scho01",
         "bibcode": "2001A&A...374L..12S",
         "doi": "10.1051/0004-6361:20010811",
         "description": "Search for nearby stars among proper motion stars selected by optical-to-infrared photometry. I. Discovery of LHS 2090 at spectroscopic distance of d ~ 6 pc"
     },
     {
-        "name": "Scho02b",
+        "publication": "Scho02b",
         "bibcode": "2002MNRAS.329..109S",
         "doi": "10.1046/j.1365-8711.2002.04945.x",
         "description": "New nearby stars among bright APM high proper motion stars"
     },
     {
-        "name": "Scho02c",
+        "publication": "Scho02c",
         "bibcode": "2002MNRAS.336L..49S",
         "doi": "10.1046/j.1365-8711.2002.05998.x",
         "description": "SSSPM J0829-1309: a new nearby L dwarf detected in SuperCOSMOS Sky Surveys"
     },
     {
-        "name": "Scho08",
+        "publication": "Scho08",
         "bibcode": "2008A&A...487..595S",
         "doi": "10.1051/0004-6361:200809797",
         "description": "An extremely wide and very low-mass pair with common proper motion. Is it representative of a nearby halo stream?"
     },
     {
-        "name": "Scho12",
+        "publication": "Scho12",
         "bibcode": "2012A&A...541A.163S",
         "doi": "10.1051/0004-6361/201218947",
         "description": "UKIDSS detections of cool brown dwarfs. Proper motions of 14 known &gt;T5 dwarfs and discovery of three new T5.5-T6 dwarfs"
     },
     {
-        "name": "Scho14a",
+        "publication": "Scho14a",
         "bibcode": "2014A&A...561A.113S",
         "doi": "10.1051/0004-6361/201323015",
         "description": "Neighbours hiding in the Galactic plane, a new M/L dwarf candidate for the 8 pc sample"
     },
     {
-        "name": "Scho14b",
+        "publication": "Scho14b",
         "bibcode": "2014A&A...567A..43S",
         "doi": "10.1051/0004-6361/201424070",
         "description": "WISEA J064750.85-154616.4: a new nearby L/T transition dwarf"
     },
     {
-        "name": "Scho16",
+        "publication": "Scho16",
         "bibcode": "2016A&A...587A..51S",
         "doi": "10.1051/0004-6361/201527965",
         "description": "Overlooked wide companions of nearby F stars"
     },
     {
-        "name": "Schr96",
+        "publication": "Schr96",
         "bibcode": "1996PASP..108..510S",
         "doi": "10.1086/133756",
         "description": "Searching for Faint Companions to Nearby Stars with the Hubble Space Telescope"
     },
     {
-        "name": "Schw99",
+        "publication": "Schw99",
         "bibcode": "1999A&A...350L..62S",
         "doi": null,
         "description": "APMPM J0559-2903: The coolest extreme subdwarf known"
     },
     {
-        "name": "Seif05a",
+        "publication": "Seif05a",
         "bibcode": "2005A&A...440..967S",
         "doi": "10.1051/0004-6361:20041902",
         "description": "The dM4.5e star G124-62 and its binary L dwarf companion DENIS-P J1441-0945. Common proper motion, distance, age, and masses"
     },
     {
-        "name": "Seif05b",
+        "publication": "Seif05b",
         "bibcode": "2005AN....326..974S",
         "doi": "10.1002/asna.200510456",
         "description": "New brown dwarf companions to dM(e) stars"
     },
     {
-        "name": "Shko10",
+        "publication": "Shko10",
         "bibcode": "2010ApJ...716.1522S",
         "doi": "10.1088/0004-637X/716/2/1522",
         "description": "Thirty New Low-mass Spectroscopic Binaries"
     },
     {
-        "name": "Shko11",
+        "publication": "Shko11",
         "bibcode": "2011ApJ...727....6S",
         "doi": "10.1088/0004-637X/727/1/6",
         "description": "Searching for Young M Dwarfs with GALEX"
     },
     {
-        "name": "Shko12",
+        "publication": "Shko12",
         "bibcode": "2012ApJ...758...56S",
         "doi": "10.1088/0004-637X/758/1/56",
         "description": "Identifying the Young Low-mass Stars within 25 pc. II. Distances, Kinematics, and Group Membership"
     },
     {
-        "name": "Shko17",
+        "publication": "Shko17",
         "bibcode": "2017AJ....154...69S",
         "doi": "10.3847/1538-3881/aa77fa",
         "description": "All-sky Co-moving Recovery Of Nearby Young Members (ACRONYM). II. The \u03b2 Pictoris Moving Group"
     },
     {
-        "name": "Silv07",
+        "publication": "Silv07",
         "bibcode": "2007AJ....134..741S",
         "doi": "10.1086/519242",
         "description": "New Close Binary Systems from the SDSS-I (Data Release Five) and the Search for Magnetic White Dwarfs in Cataclysmic Variable Progenitor Systems"
     },
     {
-        "name": "Skem16a",
+        "publication": "Skem16a",
         "bibcode": "2016ApJ...817..166S",
         "doi": "10.3847/0004-637X/817/2/166",
         "description": "The LEECH Exoplanet Imaging Survey: Characterization of the Coldest Directly Imaged Exoplanet, GJ 504 b, and Evidence for Superstellar Metallicity"
     },
     {
-        "name": "Skru06",
+        "publication": "Skru06",
         "bibcode": "2006AJ....131.1163S",
         "doi": "10.1086/498708",
         "description": "The Two Micron All Sky Survey (2MASS)"
     },
     {
-        "name": "Skru87a",
+        "publication": "Skru87a",
         "bibcode": "1987ApJ...312L..55S",
         "doi": "10.1086/184819",
         "description": "Direct Infrared Imaging of VB 8"
     },
     {
-        "name": "Skru87b",
+        "publication": "Skru87b",
         "bibcode": "1987BAAS...19.1128S",
         "doi": null,
         "description": "Discovery of an Extreme Low-mass Companion to Gleise 569"
     },
     {
-        "name": "Skrz16",
+        "publication": "Skrz16",
         "bibcode": "2016A&A...589A..49S",
         "doi": "10.1051/0004-6361/201527359",
         "description": "Photometric brown-dwarf classification. II. A homogeneous sample of 1361 L and T dwarfs brighter than J = 17.5 with accurate spectral types"
     },
     {
-        "name": "Smar18",
+        "publication": "Smar18",
         "bibcode": "2018MNRAS.481.3548S",
         "doi": "10.1093/mnras/sty2520",
         "description": "Parallaxes of Southern Extremely Cool objects III: 118 L and T dwarfs"
     },
     {
-        "name": "Smit14a",
+        "publication": "Smit14a",
         "bibcode": "2014MNRAS.437.3603S",
         "doi": "10.1093/mnras/stt2156",
         "description": "A 1500 deg<SUP>2</SUP> near infrared proper motion catalogue from the UKIDSS Large Area Survey"
     },
     {
-        "name": "Smit14b",
+        "publication": "Smit14b",
         "bibcode": "2014MNRAS.443.2327S",
         "doi": "10.1093/mnras/stu1295",
         "description": "High proper motion objects from the UKIDSS Galactic plane survey"
     },
     {
-        "name": "Smit15",
+        "publication": "Smit15",
         "bibcode": "2015MNRAS.454.4476S",
         "doi": "10.1093/mnras/stv2290",
         "description": "Discovery of a brown dwarf companion to the A3V star \u03b2 Circini"
     },
     {
-        "name": "Smit18",
+        "publication": "Smit18",
         "bibcode": "2018MNRAS.474.1826S",
         "doi": "10.1093/mnras/stx2789",
         "description": "VIRAC: the VVV Infrared Astrometric Catalogue"
     },
     {
-        "name": "Sode99",
+        "publication": "Sode99",
         "bibcode": "1999A&A...341..121S",
         "doi": null,
         "description": "Visual binary orbits and masses POST HIPPARCOS"
     },
     {
-        "name": "Song03",
+        "publication": "Song03",
         "bibcode": "2003ApJ...599..342S",
         "doi": "10.1086/379194",
         "description": "New Members of the TW Hydrae Association, \u03b2 Pictoris Moving Group, and Tucana/Horologium Association"
     },
     {
-        "name": "Stan04",
+        "publication": "Stan04",
         "bibcode": "2004ApJ...607..704S",
         "doi": "10.1086/383531",
         "description": "Hubble Space Telescope Imaging and Keck Spectroscopy of z ~ 6 i-Band Dropout Galaxies in the Advanced Camera for Surveys GOODS Fields"
     },
     {
-        "name": "Stee09",
+        "publication": "Stee09",
         "bibcode": "2009A&A...500.1207S",
         "doi": "10.1051/0004-6361/200911694",
         "description": "PHL 5038: a spatially resolved white dwarf + brown dwarf binary"
     },
     {
-        "name": "Ster07",
+        "publication": "Ster07",
         "bibcode": "2007ApJ...663..677S",
         "doi": "10.1086/516833",
         "description": "Mid-Infrared Selection of Brown Dwarfs and High-Redshift Quasars"
     },
     {
-        "name": "Stum09",
+        "publication": "Stum09",
         "bibcode": "2009AIPC.1094..561S",
         "doi": "10.1063/1.3099174",
         "description": "High-resolution AO monitoring of Kelu-1 AB"
     },
     {
-        "name": "Stum10a",
+        "publication": "Stum10a",
         "bibcode": "2010A&A...516A..37S",
         "doi": "10.1051/0004-6361/200913711",
         "description": "2MASS J03105986 +1648155 AB - a new binary at the L/T transition"
     },
     {
-        "name": "Teix00",
+        "publication": "Teix00",
         "bibcode": "2000A&A...361.1143T",
         "doi": null,
         "description": "Proper motions of pre-main sequence stars { } in southern star-forming regions"
     },
     {
-        "name": "Teix09",
+        "publication": "Teix09",
         "bibcode": "2009A&A...503..281T",
         "doi": "10.1051/0004-6361/200912173",
         "description": "Kinematic analysis and membership status of TWA22 AB"
     },
     {
-        "name": "Test09",
+        "publication": "Test09",
         "bibcode": "2009A&A...503..639T",
         "doi": "10.1051/0004-6361/200810699",
         "description": "A low-resolution near-infrared spectral library of M-, L-, and T-dwarfs"
     },
     {
-        "name": "Thac97",
+        "publication": "Thac97",
         "bibcode": "1997MNRAS.284..507T",
         "doi": "10.1093/mnras/284.2.507",
         "description": "Lithium detection in a field brown dwarf candidate"
     },
     {
-        "name": "Thal15",
+        "publication": "Thal15",
         "bibcode": "2015ApJ...808L..41T",
         "doi": "10.1088/2041-8205/808/2/L41",
         "description": "Optical Imaging Polarimetry of the LkCa 15 Protoplanetary Disk with SPHERE ZIMPOL"
     },
     {
-        "name": "Thei16",
+        "publication": "Thei16",
         "bibcode": "2016AJ....151...41T",
         "doi": "10.3847/0004-6256/151/2/41",
         "description": "Motion Verified Red Stars (MoVeRS): A Catalog of Proper Motion Selected Low-mass Stars from WISE, SDSS, and 2MASS"
     },
     {
-        "name": "Thei17a",
+        "publication": "Thei17a",
         "bibcode": "2017AJ....153...92T",
         "doi": "10.3847/1538-3881/153/3/92",
         "description": "The Late-Type Extension to MoVeRS (LaTE-MoVeRS): Proper Motion Verified Low-mass Stars and Brown Dwarfs from SDSS, 2MASS, and WISE"
     },
     {
-        "name": "Thei17b",
+        "publication": "Thei17b",
         "bibcode": "2017AJ....153..165T",
         "doi": "10.3847/1538-3881/aa6343",
         "description": "Collisions of Terrestrial Worlds: The Occurrence of Extreme Mid-infrared Excesses around Low-mass Field Stars"
     },
     {
-        "name": "Thom13",
+        "publication": "Thom13",
         "bibcode": "2013PASP..125..809T",
         "doi": "10.1086/671426",
         "description": "Nearby M, L, and T Dwarfs Discovered by the Wide-field Infrared Survey Explorer (WISE)"
     },
     {
-        "name": "Tinn93a",
+        "publication": "Tinn93a",
         "bibcode": "1993AJ....105.1045T",
         "doi": "10.1086/116492",
         "description": "The Faintest Stars: Infrared Photometry, Spectra, and Bolometric Magnitudes"
     },
     {
-        "name": "Tinn93d",
+        "publication": "Tinn93d",
         "bibcode": "1993ApJ...414..279T",
         "doi": "10.1086/173075",
         "description": "The Faintest Stars: The Luminosity and Mass Functions at the Bottom of the Main Sequence"
     },
     {
-        "name": "Tinn98a",
+        "publication": "Tinn98a",
         "bibcode": "1998MNRAS.296L..42T",
         "doi": "10.1046/j.1365-8711.1998.01642.x",
         "description": "The intermediate-age brown dwarf LP944-20"
     },
     {
-        "name": "Tinn98b",
+        "publication": "Tinn98b",
         "bibcode": "1998A&A...338.1066T",
         "doi": null,
         "description": "Optical spectroscopy of DENIS mini-survey brown dwarf candidates"
     },
     {
-        "name": "Todo10",
+        "publication": "Todo10",
         "bibcode": "2010ApJ...714L..84T",
         "doi": "10.1088/2041-8205/714/1/L84",
         "description": "Discovery of a Planetary-mass Companion to a Brown Dwarf in Taurus"
     },
     {
-        "name": "Todo14",
+        "publication": "Todo14",
         "bibcode": "2014ApJ...788...40T",
         "doi": "10.1088/0004-637X/788/1/40",
         "description": "A Search for Companions to Brown Dwarfs in the Taurus and Chamaeleon Star-Forming Regions"
     },
     {
-        "name": "Viga12",
+        "publication": "Viga12",
         "bibcode": "2012A&A...544A...9V",
         "doi": "10.1051/0004-6361/201218991",
         "description": "The International Deep Planet Survey. I. The frequency of wide-orbit massive planets around A-stars"
     },
     {
-        "name": "Wagn18",
+        "publication": "Wagn18",
         "bibcode": "2018ApJ...863L...8W",
         "doi": "10.3847/2041-8213/aad695",
         "description": "Magellan Adaptive Optics Imaging of PDS 70: Measuring the Mass Accretion Rate of a Young Giant Planet within a Gapped Disk"
     },
     {
-        "name": "Wang14",
+        "publication": "Wang14",
         "bibcode": "2014PASP..126...15W",
         "doi": "10.1086/675072",
         "description": "Parallaxes of Five L Dwarfs with a Robotic Telescope"
     },
     {
-        "name": "Wang20",
+        "publication": "Wang20",
         "bibcode": "2020AJ....159..263W",
         "doi": "10.3847/1538-3881/ab8aef",
         "description": "Keck/NIRC2 L'-band Imaging of Jovian-mass Accreting Protoplanets around PDS 70"
     },
     {
-        "name": "Warr07a",
+        "publication": "Warr07a",
         "bibcode": "2007MNRAS.375..213W",
         "doi": "10.1111/j.1365-2966.2006.11284.x",
         "description": "The United Kingdom Infrared Telescope Infrared Deep Sky Survey First Data Release"
     },
     {
-        "name": "Webb99",
+        "publication": "Webb99",
         "bibcode": "1999ApJ...512L..63W",
         "doi": "10.1086/311856",
         "description": "Discovery of Seven T Tauri Stars and a Brown Dwarf Candidatein the Nearby TW Hydrae Association"
     },
     {
-        "name": "West11",
+        "publication": "West11",
         "bibcode": "2011AJ....141...97W",
         "doi": "10.1088/0004-6256/141/3/97",
         "description": "The Sloan Digital Sky Survey Data Release 7 Spectroscopic M Dwarf Catalog. I. Data"
     },
     {
-        "name": "West15",
+        "publication": "West15",
         "bibcode": "2015ApJ...812....3W",
         "doi": "10.1088/0004-637X/812/1/3",
         "description": "An Activity-Rotation Relationship and Kinematic Analysis of Nearby Mid-to-Late-Type M Dwarfs"
     },
     {
-        "name": "Wint17",
+        "publication": "Wint17",
         "bibcode": "2017AJ....153...14W",
         "doi": "10.3847/1538-3881/153/1/14",
         "description": "The Solar Neighborhood XXXVIII. Results from the CTIO/SMARTS 0.9m: Trigonometric Parallaxes for 151 Nearby M Dwarf Systems"
     },
     {
-        "name": "Wint19",
+        "publication": "Wint19",
         "bibcode": "2019AJ....157..216W",
         "doi": "10.3847/1538-3881/ab05dc",
         "description": "The Solar Neighborhood. XLV. The Stellar Multiplicity Rate of M Dwarfs Within 25 pc"
     },
     {
-        "name": "Wrig13",
+        "publication": "Wrig13",
         "bibcode": "2013AJ....145...84W",
         "doi": "10.1088/0004-6256/145/3/84",
         "description": "A T8.5 Brown Dwarf Member of the \u03be Ursae Majoris System"
     },
     {
-        "name": "Wrig14b",
+        "publication": "Wrig14b",
         "bibcode": "2014AJ....148...82W",
         "doi": "10.1088/0004-6256/148/5/82",
         "description": "NEOWISE-R Observation of the Coolest Known Brown Dwarf"
     },
     {
-        "name": "Wu__15a",
+        "publication": "Wu__15a",
         "bibcode": "2015ApJ...801....4W",
         "doi": "10.1088/0004-637X/801/1/4",
         "description": "New Extinction and Mass Estimates from Optical Photometry of the Very Low Mass Brown Dwarf Companion CT Chamaeleontis B with the Magellan AO System"
     },
     {
-        "name": "Wu__15b",
+        "publication": "Wu__15b",
         "bibcode": "2015ApJ...807L..13W",
         "doi": "10.1088/2041-8205/807/1/L13",
         "description": "New Extinction and Mass Estimates of the Low-mass Companion 1RXS 1609 B with the Magellan AO System: Evidence of an Inclined Dust Disk"
     },
     {
-        "name": "Wu__16",
+        "publication": "Wu__16",
         "bibcode": "2016ApJ...823...24W",
         "doi": "10.3847/0004-637X/823/1/24",
         "description": "Magellan AO System z\u2027, Y <SUB> S </SUB>, and L\u2027 Observations of the Very Wide 650 AU HD 106906 Planetary System"
     },
     {
-        "name": "Wu__17",
+        "publication": "Wu__17",
         "bibcode": "2017ApJ...836..223W",
         "doi": "10.3847/1538-4357/aa5b96",
         "description": "An ALMA and MagAO Study of the Substellar Companion GQ Lup B*"
     },
     {
-        "name": "Zach03",
+        "publication": "Zach03",
         "bibcode": "2003yCat.1289....0Z",
         "doi": null,
         "description": "UCAC2 Catalogue (Zacharias+ 2004)"
     },
     {
-        "name": "Zach05",
+        "publication": "Zach05",
         "bibcode": "2005yCat.1297....0Z",
         "doi": null,
         "description": "VizieR Online Data Catalog: NOMAD Catalog (Zacharias+ 2005)"
     },
     {
-        "name": "Zach09",
+        "publication": "Zach09",
         "bibcode": "2009yCat.1315....0Z",
         "doi": null,
         "description": "UCAC3 Catalogue (Zacharias+ 2009)"
     },
     {
-        "name": "Zach10",
+        "publication": "Zach10",
         "bibcode": "2010AJ....139.2184Z",
         "doi": "10.1088/0004-6256/139/6/2184",
         "description": "The Third US Naval Observatory CCD Astrograph Catalog (UCAC3)"
     },
     {
-        "name": "Zach13",
+        "publication": "Zach13",
         "bibcode": "2013AJ....145...44Z",
         "doi": "10.1088/0004-6256/145/2/44",
         "description": "The Fourth US Naval Observatory CCD Astrograph Catalog (UCAC4)"
     },
     {
-        "name": "Zach15",
+        "publication": "Zach15",
         "bibcode": "2015AJ....150..101Z",
         "doi": "10.1088/0004-6256/150/4/101",
         "description": "The First U.S. Naval Observatory Robotic Astrometric Telescope Catalog"
     },
     {
-        "name": "Zapa00",
+        "publication": "Zapa00",
         "bibcode": "2000Sci...290..103Z",
         "doi": "10.1126/science.290.5489.103",
         "description": "Discovery of Young, Isolated Planetary Mass Objects in the \u03c3 Orionis Star Cluster"
     },
     {
-        "name": "Zapa02c",
+        "publication": "Zapa02c",
         "bibcode": "2002ApJ...578..536Z",
         "doi": "10.1086/342474",
         "description": "A Methane, Isolated, Planetary-Mass Object in Orion"
     },
     {
-        "name": "Zapa04b",
+        "publication": "Zapa04b",
         "bibcode": "2004ApJ...615..958Z",
         "doi": "10.1086/424507",
         "description": "Dynamical Masses of the Binary Brown Dwarf GJ 569 Bab"
     },
     {
-        "name": "Zapa08",
+        "publication": "Zapa08",
         "bibcode": "2008A&A...477..895Z",
         "doi": "10.1051/0004-6361:20078600",
         "description": "New constraints on the membership of the T dwarf S Ori 70 in the \u03c3 Orionis cluster"
     },
     {
-        "name": "Zapa99a",
+        "publication": "Zapa99a",
         "bibcode": "1999A&AS..134..537Z",
         "doi": "10.1051/aas:1999443",
         "description": "Brown dwarfs in the Pleiades cluster. III. A deep IZ survey"
     },
     {
-        "name": "Zapa99b",
+        "publication": "Zapa99b",
         "bibcode": "1999ApJ...524L.115Z",
         "doi": "10.1086/312317",
         "description": "An L-Type Substellar Object in Orion: Reaching the Mass Boundary between Brown Dwarfs and Giant Planets"
     },
     {
-        "name": "Zhan13",
+        "publication": "Zhan13",
         "bibcode": "2013MNRAS.434.1005Z",
         "doi": "10.1093/mnras/stt1030",
         "description": "A spectroscopic and proper motion search of Sloan Digital Sky Survey: red subdwarfs in binary systems"
     },
     {
-        "name": "Zhan19a",
+        "publication": "Zhan19a",
         "bibcode": "2019MNRAS.486.1840Z",
         "doi": "10.1093/mnras/stz659",
         "description": "Primeval very low-mass stars and brown dwarfs - V. A halo L3 subdwarf with prograde eccentric orbit in the Galactic plane"
     },
     {
-        "name": "Zhan19b",
+        "publication": "Zhan19b",
         "bibcode": "2019MNRAS.486.1260Z",
         "doi": "10.1093/mnras/stz777",
         "description": "Primeval very low-mass stars and brown dwarfs - VI. Population properties of metal-poor degenerate brown dwarfs"
     },
     {
-        "name": "Zhan19c",
+        "publication": "Zhan19c",
         "bibcode": "2019MNRAS.489.1423Z",
         "doi": "10.1093/mnras/stz2196",
         "description": "Primeval very low-mass stars and brown dwarfs - VII. The discovery of the first wide M + L extreme subdwarf binary"
     },
     {
-        "name": "Zhou14",
+        "publication": "Zhou14",
         "bibcode": "2014ApJ...783L..17Z",
         "doi": "10.1088/2041-8205/783/1/L17",
         "description": "Accretion onto Planetary Mass Companions of Low-mass Young Stars"
     },
     {
-        "name": "Zhou20",
+        "publication": "Zhou20",
         "bibcode": "2020AJ....159..140Z",
         "doi": "10.3847/1538-3881/ab6f65",
         "description": "Cloud Atlas: High-precision HST/WFC3/IR Time-resolved Observations of Directly Imaged Exoplanet HD 106906b"
     },
     {
-        "name": "Zuck06",
+        "publication": "Zuck06",
         "bibcode": "2006ApJ...649L.115Z",
         "doi": "10.1086/508060",
         "description": "The Carina-Near Moving Group"
     },
     {
-        "name": "Zuck92a",
+        "publication": "Zuck92a",
         "bibcode": "1992ApJ...386..260Z",
         "doi": "10.1086/171012",
         "description": "Companions to White Dwarfs: Very Low Mass Stars and the Brown Dwarf Candidate GD 165B"
     },
     {
-        "name": "Gizi00c",
+        "publication": "Gizi00c",
         "bibcode": "2000AJ....120.1085G",
         "doi": "10.1086/301456",
         "description": "New Neighbors from 2MASS: Activity and Kinematics at the Bottom of the Main Sequence"
     },
     {
-        "name": "Luhm09",
+        "publication": "Luhm09",
         "bibcode": "2009ApJ...691.1265L",
         "doi": "10.1088/0004-637X/691/2/1265",
         "description": "Discovery of a Wide Binary Brown Dwarf Born in Isolation"
     },
     {
-        "name": "Metc04",
+        "publication": "Metc04",
         "bibcode": "2004ApJ...617.1330M",
         "doi": "10.1086/425410",
         "description": "Initial Results from the Palomar Adaptive Optics Survey of Young Solar-Type Stars: A Brown Dwarf and Three Stellar Companions"
     },
     {
-        "name": "Metc06",
+        "publication": "Metc06",
         "bibcode": "2006ApJ...651.1166M",
         "doi": "10.1086/507836",
         "description": "HD 203030B: An Unusually Cool Young Substellar Companion near the L/T Transition"
     },
     {
-        "name": "Gaia",
+        "publication": "Gaia",
         "bibcode": "2016A&A...595A...1G",
         "doi": "10.1051/0004-6361/201629272",
         "description": "The Gaia mission"
     },
     {
-        "name": "GaiaEDR3",
+        "publication": "GaiaEDR3",
         "bibcode": "2021A&A...649A...1G",
         "doi": "10.1051/0004-6361/202039657",
         "description": "Gaia Early Data Release 3. Summary of the contents and survey properties"

--- a/data/Publications.json
+++ b/data/Publications.json
@@ -1597,8 +1597,8 @@
     },
     {
         "publication": "Zapa04",
-        "bibcode": "2004astro.ph..7334O",
-        "doi": null,
+        "bibcode": "2004ApJ...615..958Z",
+        "doi": "10.1086/424507",
         "description": "Dynamical Masses of the Binary Brown Dwarf GJ 569Bab"
     },
     {
@@ -1915,7 +1915,7 @@
     },
     {
         "publication": "Gold99",
-        "bibcode": "1999A&A...351L...5G",
+        "bibcode": "1999A&A...351L...5E",
         "doi": null,
         "description": "EROS 2 proper motion survey: a field brown dwarf, and an L dwarf companion to LHS 102"
     },
@@ -2564,7 +2564,7 @@
     {
         "publication": "Moun90",
         "bibcode": "1990SPIE.1235...25M",
-        "doi": null,
+        "doi": "10.1117/12.19068",
         "description": "An advanced cooled grating spectrometer for UKIRT"
     },
     {
@@ -3638,7 +3638,7 @@
     {
         "publication": "Mart18",
         "bibcode": "2018ApJ...867..109M",
-        "doi": null,
+        "doi": "10.3847/1538-4357/aae1af",
         "description": null
     },
     {
@@ -3662,37 +3662,31 @@
     {
         "publication": "Sahl16",
         "bibcode": "2016MNRAS.455..357S",
-        "doi": null,
-        "description": null
-    },
-    {
-        "publication": "Liu16",
-        "bibcode": "J/ApJ/833/96",
-        "doi": null,
+        "doi": "10.1093/mnras/stv2266",
         "description": null
     },
     {
         "publication": "Wang18",
         "bibcode": "2018PASP..130f4402W",
-        "doi": null,
+        "doi": "10.1088/1538-3873/aaacc5",
         "description": null
     },
     {
         "publication": "Bedi17",
         "bibcode": "2017MNRAS.470.1140B",
-        "doi": null,
+        "doi": "10.1093/mnras/stx1177",
         "description": null
     },
     {
         "publication": "Delo17b",
         "bibcode": "2017A&A...608A..79D",
-        "doi": null,
+        "doi": "10.1051/0004-6361/201731145",
         "description": null
     },
     {
         "publication": "Luhm16",
         "bibcode": "2016AJ....152...78L",
-        "doi": null,
+        "doi": "10.3847/0004-6256/152/3/78",
         "description": null
     },
     {
@@ -3703,7 +3697,7 @@
     },
     {
         "publication": "Card12",
-        "bibcode": "2012PhDT.........?C",
+        "bibcode": "2012PhDT.......463C",
         "doi": null,
         "description": "Observational properties of brown dwarfs: The low-mass end of the mass function"
     },

--- a/documentation/Publications.md
+++ b/documentation/Publications.md
@@ -7,13 +7,13 @@ Columns marked with an asterisk (*) may not be empty.
 
 | Column Name | Description  | Unit  | Data Type | Key Type  |
 |---|---|---|---|---|
-| *name          | Unique identifier for the publication |   | String(30)  | primary   |
+| *publication          | Unique identifier for the publication |   | String(30)  | primary   |
 | bibcode       | ADS Bibcode entry |   | String(100)  |    |
 | doi           | Document Object Identifier (DOI) |   | String(100)  |    |
 | description   | Publication description, optional |   | String(1000)  |    |
 
 ## Notes
-- Publication `Name` is typically a six letter string consisting of first four letters of first author name and two digit year. 
+- Publication `Publication` is typically a six letter string consisting of first four letters of first author name and two digit year. 
   - Smith et al. 2020 would be `Smit20`.
   - In the case of short last names, either first letters of first name or underscores can be used to construct the four letter string. 
     For example, `WuXi21` or `Wu__21`

--- a/scripts/ingests/utils.py
+++ b/scripts/ingests/utils.py
@@ -419,45 +419,5 @@ def ingest_publication(db, doi: str = None, bibcode: str = None, name: str = Non
     return
 
 
-# TODO: write update_publication function
-# def update_publication(db, doi: str = None, bibcode: str = None, name: str = None, description: str = None,
-#                        save_db: bool = True):
-#     """
-#     Updates publications in the database, including metadata found with ADS.
-#
-#     In order to auto-populate the fields, An $ADS_TOKEN environment variable must be set.
-#     See https://ui.adsabs.harvard.edu/user/settings/token
-#
-#     Parameters
-#     ----------
-#     db
-#         Database object
-#     doi, bibcode: str
-#         The DOI or ADS Bibcode of the reference.
-#     name: str, optional
-#         The publication shortname, otherwise it will be generated [optional]
-#     description: str, optional
-#         Description of the paper, typically the title of the papre [optional]
-#     save_db: bool
-#
-#     See Also
-#     --------
-#     search_publication: Function to find publications in the database
-#     add_publication: Function to add publications to the database
-#
-#     """
-#
-#     # TODO: provide an option to add missing information
-#     #     add_doi_bibcode = db.Publications.update().where(db.Publications.c.name == 'Manj19'). \
-#     #         values(bibcode='2019AJ....157..101M', doi='10.3847/1538-3881/aaf88f',
-#     #               description='Cloud Atlas: HST nir spectral library')
-#     #     db.engine.execute(add_doi_bibcode)
-#
-#     # change_name = db.Publications.update().where(db.Publications.c.name == 'Wein12'). \
-#     #         values(name='Wein13')
-#     #     db.engine.execute(change_name)
-#
-#     return
-
 
 

--- a/scripts/ingests/utils.py
+++ b/scripts/ingests/utils.py
@@ -217,7 +217,7 @@ def find_publication(db, name: str = None, doi: str = None, bibcode: str = None)
     not_null_pub_filters = []
     if name:
         # fuzzy_query_name = '%' + name + '%'
-        not_null_pub_filters.append(db.Publications.c.name.ilike(name))
+        not_null_pub_filters.append(db.Publications.c.publication.ilike(name))
     if doi:
         not_null_pub_filters.append(db.Publications.c.doi.ilike(doi))
     if bibcode:
@@ -247,7 +247,7 @@ def find_publication(db, name: str = None, doi: str = None, bibcode: str = None)
         logger.debug(f'No matching publications for {name}, Trying {shorter_name}')
         fuzzy_query_shorter_name = '%' + shorter_name + '%'
         pub_search_table = db.query(db.Publications).filter(
-            db.Publications.c.name.ilike(fuzzy_query_shorter_name)).table()
+            db.Publications.c.publication.ilike(fuzzy_query_shorter_name)).table()
         n_pubs_found_short = len(pub_search_table)
         if n_pubs_found_short == 0:
             logger.warning(f'No matching publications for {shorter_name}')
@@ -403,7 +403,7 @@ def ingest_publication(db, doi: str = None, bibcode: str = None, name: str = Non
         bibcode_add = bibcode
         doi_add = doi
 
-    new_ref = [{'name': name_add, 'bibcode': bibcode_add, 'doi': doi_add, 'description': description}]
+    new_ref = [{'publication': name_add, 'bibcode': bibcode_add, 'doi': doi_add, 'description': description}]
 
     try:
         db.Publications.insert().execute(new_ref)

--- a/scripts/updates/update_publications.py
+++ b/scripts/updates/update_publications.py
@@ -58,3 +58,5 @@ for pub in missing_dois:
             logger.debug(msg)
 
 logger.info(f"{n_no_doi} pubs with no DOI \n {n_added_doi} DOIs added")
+
+db.save_database('data/')

--- a/scripts/updates/update_publications.py
+++ b/scripts/updates/update_publications.py
@@ -1,0 +1,60 @@
+from scripts.ingests.utils import *
+
+logger.setLevel(logging.INFO)
+
+ads.config.token = os.getenv('ADS_TOKEN')
+
+if not ads.config.token:
+    logger.error("An ADS_TOKEN environment variable must be set in order to auto-populate the fields.")
+    raise SimpleError
+
+db = load_simpledb('SIMPLE.db', recreatedb=True)
+
+# Update individual publications
+db.Publications.update().where(db.Publications.c.publication == 'Zapa04').values(bibcode='2004ApJ...615..958Z').execute()
+db.Publications.update().where(db.Publications.c.publication == 'Card12').values(bibcode='2012PhDT.......463C').execute()
+db.Publications.update().where(db.Publications.c.publication == 'Gold99').values(bibcode='1999A&A...351L...5E').execute()
+db.Parallaxes.update().where(db.Parallaxes.c.reference == 'Liu16').values(reference='Liu_16').execute()
+db.Publications.delete().where(db.Publications.c.publication == 'Liu16').execute()
+
+# Find publications missig DOIs that have Bibcodes
+missing_dois = db.query(db.Publications).filter(or_(db.Publications.c.doi == None, db.Publications.c.doi == ''),
+                                                and_(db.Publications.c.bibcode != None, db.Publications.c.bibcode != '')).table()
+n_missing_dois = len(missing_dois)
+logger.info(f"Searching for data on {n_missing_dois} publications missing DOIs with ADS Bibcodes")
+
+n_added_doi = 0
+n_no_doi = 0
+
+for pub in missing_dois:
+    pub_name = pub['publication']
+    bibcode = pub['bibcode']
+    logger.debug(f"Searching ADS for {bibcode}")
+    bibcode_matches = ads.SearchQuery(bibcode=bibcode, fl=['id', 'bibcode', 'title', 'first_author', 'year', 'doi'])
+    bibcode_matches_list = list(bibcode_matches)
+    if len(bibcode_matches_list) == 0:
+        logger.error('not a valid bibcode:' + str(bibcode))
+        logger.error('nothing added')
+        continue
+    elif len(bibcode_matches_list) > 1:
+        logger.error('should only be one matching bibcode for:' + str(bibcode))
+        logger.error('nothing added')
+        continue
+    elif len(bibcode_matches_list) == 1:
+        logger.debug("Publication found in ADS using bibcode: " + str(bibcode))
+        article = bibcode_matches_list[0]
+        if article.doi is not None:
+            doi_add = article.doi[0]
+            try:
+                db.Publications.update().where(db.Publications.c.publication == pub_name).values(doi=doi_add).execute()
+                n_added_doi += 1
+                logger.info(f"Added DOI: {article.first_author}, {article.year}, {article.bibcode}, {article.doi}, {article.title}")
+            except:
+                logger.error('adding DOI failed')
+                raise SimpleError
+        else:
+            n_no_doi += 1
+            msg = f"{pub_name} DOI is None"
+            logger.debug(msg)
+
+logger.info(f"{n_no_doi} pubs with no DOI \n {n_added_doi} DOIs added")

--- a/simple/schema.py
+++ b/simple/schema.py
@@ -13,7 +13,7 @@ class Publications(Base):
     This stores reference information (DOI, bibcodes, etc) and has shortname as the primary key
     """
     __tablename__ = 'Publications'
-    name = Column(String(30), primary_key=True, nullable=False)
+    publication = Column(String(30), primary_key=True, nullable=False)
     bibcode = Column(String(100))
     doi = Column(String(100))
     description = Column(String(1000))

--- a/simple/schema.py
+++ b/simple/schema.py
@@ -22,13 +22,13 @@ class Publications(Base):
 class Telescopes(Base):
     __tablename__ = 'Telescopes'
     name = Column(String(30), primary_key=True, nullable=False)
-    reference = Column(String(30), ForeignKey('Publications.name', onupdate='cascade'))
+    reference = Column(String(30), ForeignKey('Publications.publication', onupdate='cascade'))
 
 
 class Instruments(Base):
     __tablename__ = 'Instruments'
     name = Column(String(30), primary_key=True, nullable=False)
-    reference = Column(String(30), ForeignKey('Publications.name', onupdate='cascade'))
+    reference = Column(String(30), ForeignKey('Publications.publication', onupdate='cascade'))
 
 
 class Modes(Base):
@@ -94,7 +94,7 @@ class Sources(Base):
     epoch = Column(Float)  # decimal year
     equinox = Column(String(10))  # eg, J2000
     shortname = Column(String(30))  # not needed?
-    reference = Column(String(30), ForeignKey('Publications.name', onupdate='cascade'), nullable=False)
+    reference = Column(String(30), ForeignKey('Publications.publication', onupdate='cascade'), nullable=False)
     comments = Column(String(1000))
 
 
@@ -118,7 +118,7 @@ class Photometry(Base):
     instrument = Column(String(30))
     epoch = Column(Float)  # decimal year
     comments = Column(String(1000))
-    reference = Column(String(30), ForeignKey('Publications.name', onupdate='cascade'), primary_key=True)
+    reference = Column(String(30), ForeignKey('Publications.publication', onupdate='cascade'), primary_key=True)
 
     # Foreign key constraints for telescope, instrument, band; all handled via reference to Modes table
     __table_args__ = (ForeignKeyConstraint([telescope, instrument, band],
@@ -137,7 +137,7 @@ class Parallaxes(Base):
     parallax_error = Column(Float)
     adopted = Column(Boolean)  # flag for indicating if this is the adopted measurement or not
     comments = Column(String(1000))
-    reference = Column(String(30), ForeignKey('Publications.name', onupdate='cascade'), primary_key=True)
+    reference = Column(String(30), ForeignKey('Publications.publication', onupdate='cascade'), primary_key=True)
 
 
 class ProperMotions(Base):
@@ -151,7 +151,7 @@ class ProperMotions(Base):
     mu_dec_error = Column(Float)
     adopted = Column(Boolean)  # flag for indicating if this is the adopted measurement or not
     comments = Column(String(1000))
-    reference = Column(String(30), ForeignKey('Publications.name', onupdate='cascade'), primary_key=True)
+    reference = Column(String(30), ForeignKey('Publications.publication', onupdate='cascade'), primary_key=True)
 
 
 class RadialVelocities(Base):
@@ -163,7 +163,7 @@ class RadialVelocities(Base):
     radial_velocity_error = Column(Float)
     adopted = Column(Boolean)  # flag for indicating if this is the adopted measurement or not
     comments = Column(String(1000))
-    reference = Column(String(30), ForeignKey('Publications.name', onupdate='cascade'), primary_key=True)
+    reference = Column(String(30), ForeignKey('Publications.publication', onupdate='cascade'), primary_key=True)
 
 
 class SpectralTypes(Base):
@@ -177,7 +177,7 @@ class SpectralTypes(Base):
     regime = Column(Enum(Regime, create_constraint=True), primary_key=True)  # restricts to a few values: Optical, Infrared
     adopted = Column(Boolean)  # flag for indicating if this is the adopted measurement or not
     comments = Column(String(1000))
-    reference = Column(String(30), ForeignKey('Publications.name', onupdate='cascade'), primary_key=True)
+    reference = Column(String(30), ForeignKey('Publications.publication', onupdate='cascade'), primary_key=True)
 
 
 class Gravities(Base):
@@ -188,7 +188,7 @@ class Gravities(Base):
     gravity = Column(Enum(Gravity, create_constraint=True), nullable=False)  # restricts to enumerated values
     regime = Column(Enum(Regime, create_constraint=True), primary_key=True)  # restricts to a few values: Optical, Infrared
     comments = Column(String(1000))
-    reference = Column(String(30), ForeignKey('Publications.name', onupdate='cascade'), primary_key=True)
+    reference = Column(String(30), ForeignKey('Publications.publication', onupdate='cascade'), primary_key=True)
 
 
 class Spectra(Base):
@@ -213,7 +213,7 @@ class Spectra(Base):
 
     # Common metadata
     comments = Column(String(1000))
-    reference = Column(String(30), ForeignKey('Publications.name', onupdate='cascade'), primary_key=True)
+    reference = Column(String(30), ForeignKey('Publications.publication', onupdate='cascade'), primary_key=True)
 
     # Foreign key constraints for telescope, instrument, mode; all handled via reference to Modes table
     __table_args__ = (ForeignKeyConstraint([telescope, instrument, mode],

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -41,7 +41,7 @@ def db():
 # -----------------------------------------------------------------------------------------
 def reference_verifier(t, name, bibcode, doi):
     # Utility function to verify reference values in a table
-    ind = t['name'] == name
+    ind = t['publication'] == name
     assert t[ind]['bibcode'][0] == bibcode, f'{name} did not match bibcode'
     assert t[ind]['doi'][0] == doi, f'{name} did not match doi'
 
@@ -318,7 +318,7 @@ def test_Manj19_pub(db):
     pub = 'Manj19'
 
     # Check DOI and Bibcode values are correctly set for new publications added
-    manj19_pub = db.query(db.Publications).filter(db.Publications.c.name == pub).astropy()
+    manj19_pub = db.query(db.Publications).filter(db.Publications.c.publication == pub).astropy()
     reference_verifier(manj19_pub, 'Manj19', '2019AJ....157..101M', '10.3847/1538-3881/aaf88f')
 
 
@@ -343,7 +343,7 @@ def test_Kirk19_ingest(db):
     # Test refereces added
     ref_list = ['Tinn18', 'Pinf14', 'Mace13', 'Kirk12', 'Cush11', 'Kirk13',
                 'Schn15', 'Luhm14b', 'Tinn14', 'Tinn12', 'Cush14', 'Kirk19']
-    t = db.query(db.Publications).filter(db.Publications.c.name.in_(ref_list)).astropy()
+    t = db.query(db.Publications).filter(db.Publications.c.publication.in_(ref_list)).astropy()
 
     if len(ref_list) != len(t):
         missing_ref = list(set(ref_list)-set(t['name']))

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -42,17 +42,17 @@ def test_data_load(db):
 
 def test_reference_uniqueness(db):
     # Verify that all Publications.name values are unique
-    t = db.query(db.Publications.c.name).astropy()
-    assert len(t) == len(unique(t, keys='name')), 'Duplicated Publications found'
+    t = db.query(db.Publications.c.publication).astropy()
+    assert len(t) == len(unique(t, keys='publication')), 'Duplicated Publications found'
 
     # Verify that DOI are supplied
-    t = db.query(db.Publications.c.name).filter(db.Publications.c.doi.is_(None)).astropy()
+    t = db.query(db.Publications.c.publication).filter(db.Publications.c.doi.is_(None)).astropy()
     if len(t) > 0:
         print(f'\n{len(t)} publications lacking DOI:')
         print(t)
 
     # Verify that Bibcodes are supplied
-    t = db.query(db.Publications.c.name).filter(db.Publications.c.bibcode.is_(None)).astropy()
+    t = db.query(db.Publications.c.publication).filter(db.Publications.c.bibcode.is_(None)).astropy()
     if len(t) > 0:
         print(f'\n{len(t)} publications lacking Bibcodes:')
         print(t)
@@ -72,11 +72,11 @@ def test_references(db):
     ref_list = list(set(ref_list))
 
     # Confirm that all are in Publications
-    t = db.query(db.Publications.c.name).filter(db.Publications.c.name.in_(ref_list)).astropy()
+    t = db.query(db.Publications.c.publication).filter(db.Publications.c.publication.in_(ref_list)).astropy()
     assert len(t) == len(ref_list), 'Some references were not matched'
 
     # List out publications that have not been used
-    t = db.query(db.Publications.c.name).filter(db.Publications.c.name.notin_(ref_list)).astropy()
+    t = db.query(db.Publications.c.publication).filter(db.Publications.c.publication.notin_(ref_list)).astropy()
     if len(t) > 0:
         print(f'\n{len(t)} publications not referenced by {table_list}')
         print(t)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -58,8 +58,8 @@ def t_pm():
 
 def test_setup_db(db):
     # Some setup tasks to ensure some data exists in the database first
-    ref_data = [{'name': 'Ref 1', 'doi': '10.1093/mnras/staa1522', 'bibcode': '2020MNRAS.496.1922B'},
-                {'name': 'Ref 2', 'doi': 'Doi2', 'bibcode': '2012yCat.2311....0C'}]
+    ref_data = [{'publication': 'Ref 1', 'doi': '10.1093/mnras/staa1522', 'bibcode': '2020MNRAS.496.1922B'},
+                {'publication': 'Ref 2', 'doi': 'Doi2', 'bibcode': '2012yCat.2311....0C'}]
     db.Publications.insert().execute(ref_data)
 
     source_data = [{'source': 'Fake 1', 'ra': 9.0673755, 'dec': 18.352889, 'reference': 'Ref 1'},


### PR DESCRIPTION
- Changes Publication.name to Publication.publication
- Script to add DOIs to publications with ADS bibcodes
- Fixes to 4 publications
- DOIs added to 8 publications
- remove update_publication function from utils