### PR TITLE
Mission Tests

### DIFF
--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -253,7 +253,6 @@ def test_missions(db):
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 265, f'found {len(stm)} spectra with 2MASS designation that have no 2MASS photometry'
-
     # If 2MASS photometry, 2MASS designation should be in Names
 
     # If Gaia designation in Names, Gaia phot and astrometry should exist

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -254,8 +254,12 @@ def test_missions(db):
     s = result.scalars().all()
     assert len(s) == 265, f'found {len(stm)} spectra with 2MASS designation that have no 2MASS photometry'
     # If 2MASS photometry, 2MASS designation should be in Names
-
-    # If Gaia designation in Names, Gaia phot and astrometry should exist
+    stm = except_(select([db.Photometry.c.source]).where(db.Photometry.c.band.like("2MASS%")),
+                  select([db.Names.c.source]).where(db.Names.c.other_name.like("2MASS J%")))
+    result = db.session.execute(stm)
+    s = result.scalars().all()
+    assert len(s) == 0, f'found {len(stm)} spectra with 2MASS photometry that have no 2MASS designation '
+    # If Gaia designation in Names, Gaia photometry and astrometry should exist
     stm = except_(select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia%")),
                   select([db.Photometry.c.source]).where(db.Photometry.c.band.like("GAIA%")))
     result = db.session.execute(stm)
@@ -267,8 +271,25 @@ def test_missions(db):
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 0, f'found {len(stm)} spectra with Gaia photometry and no Gaia designation in Names'
-# If Gaia pm, Gaia designation should be in Names
-# If Gaia parallax, Gaia designation should be in Names
+    # If Wise designation in Names, Wise phot should exist
+    stm = except_(select([db.Names.c.source]).where(db.Names.c.other_name.like("WISE%")),
+                  select([db.Photometry.c.source]).where(db.Photometry.c.band.like("WISE%")))
+    result = db.session.execute(stm)
+    s = result.scalars().all()
+    assert len(s) == 392, f'found {len(stm)} spectra with WISE designation that have no WISE photometry'
+    # If Wise photometry, Wise designation should be in Names
+    stm = except_(select([db.Photometry.c.source]).where(db.Photometry.c.band.like("WISE%")),
+                  select([db.Names.c.source]).where(db.Names.c.other_name.like("WISE%")))
+    result = db.session.execute(stm)
+    s = result.scalars().all()
+    assert len(s) == 278, f'found {len(stm)} spectra with Wise photometry and no Wise designation in Names'
+    # If Gaia pm, Gaia designation should be in Names
+    stm = except_(select([db.ProperMotions.c.source]).where(db.Photometry.c.reference.like("GaiaDR2")),
+                  select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia DR2")))
+    result = db.session.execute(stm)
+    s = result.scalars().all()
+    assert len(s) == 0, f'found {len(stm)} spectra with Gaia DR2 proper motions and no Gaia DR2 designation in Names'
+    # If Gaia parallax, Gaia designation should be in Names
 
 
 def test_spectra(db):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -262,8 +262,12 @@ def test_missions(db):
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 1, f'found {len(stm)} spectra with Gaia designation that have no GAIA photometry'
-
-# If Gaia photometry, Gaia designation should be in Names
+    # If Gaia photometry, Gaia designation should be in Names
+    stm = except_(select([db.Photometry.c.source]).where(db.Photometry.c.band.like("GAIA%")),
+                  select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia%")))
+    result = db.session.execute(stm)
+    s = result.scalars().all()
+    assert len(s) == 0, f'found {len(stm)} spectra with Gaia photometry and no Gaia designation in Names'
 # If Gaia pm, Gaia designation should be in Names
 # If Gaia parallax, Gaia designation should be in Names
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -245,77 +245,62 @@ def test_photometry_bands(db):
     assert len(t) == 1751, f'found {len(t)} photometry measurements for {band}'
 
 
-# TODO: Tests of Gaia and 2MASS designations
 def test_missions(db):
     # If 2MASS designation in Names, 2MASS photometry should exist
     stm = except_(select([db.Names.c.source]).where(db.Names.c.other_name.like("2MASS J%")),
                   select([db.Photometry.c.source]).where(db.Photometry.c.band.like("2MASS%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
-    assert len(s) == 265, f'found {len(stm)} spectra with 2MASS designation that have no 2MASS photometry'
+    assert len(s) == 265, f'found {len(s)} sources with 2MASS designation that have no 2MASS photometry'
 
     # If 2MASS photometry, 2MASS designation should be in Names
     stm = except_(select([db.Photometry.c.source]).where(db.Photometry.c.band.like("2MASS%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("2MASS J%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
-    assert len(s) == 0, f'found {len(stm)} spectra with 2MASS photometry that have no 2MASS designation '
+    assert len(s) == 0, f'found {len(s)} sources with 2MASS photometry that have no 2MASS designation '
 
     # If Gaia designation in Names, Gaia photometry and astrometry should exist
     stm = except_(select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia%")),
                   select([db.Photometry.c.source]).where(db.Photometry.c.band.like("GAIA%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
-    assert len(s) == 1, f'found {len(stm)} spectra with Gaia designation that have no GAIA photometry'
+    assert len(s) == 1, f'found {len(s)} sources with Gaia designation that have no GAIA photometry'
 
     # If Gaia photometry, Gaia designation should be in Names
     stm = except_(select([db.Photometry.c.source]).where(db.Photometry.c.band.like("GAIA%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
-    assert len(s) == 0, f'found {len(stm)} spectra with Gaia photometry and no Gaia designation in Names'
+    assert len(s) == 0, f'found {len(s)} sources with Gaia photometry and no Gaia designation in Names'
 
     # If Wise designation in Names, Wise phot should exist
     stm = except_(select([db.Names.c.source]).where(db.Names.c.other_name.like("WISE%")),
                   select([db.Photometry.c.source]).where(db.Photometry.c.band.like("WISE%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
-    assert len(s) == 392, f'found {len(stm)} spectra with WISE designation that have no WISE photometry'
+    assert len(s) == 392, f'found {len(s)} sources with WISE designation that have no WISE photometry'
 
     # If Wise photometry, Wise designation should be in Names
     stm = except_(select([db.Photometry.c.source]).where(db.Photometry.c.band.like("WISE%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("WISE%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
-    assert len(s) == 278, f'found {len(stm)} spectra with Wise photometry and no Wise designation in Names'
-
-    # If Gaia DR2 pm, Gaia DR2 designation should be in Names
-    stm = except_(select([db.ProperMotions.c.source]).where(db.ProperMotions.c.reference.like("GaiaDR2%")),
-                  select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia DR2%")))
-    result = db.session.execute(stm)
-    s = result.scalars().all()
-    assert len(s) == 0, f'found {len(stm)} spectra with Gaia DR2 proper motion and no Gaia DR2 designation in Names'
+    assert len(s) == 278, f'found {len(s)} sources with WISE photometry and no Wise designation in Names'
 
     # If Gaia EDR3 pm, Gaia EDR3 designation should be in Names
     stm = except_(select([db.ProperMotions.c.source]).where(db.ProperMotions.c.reference.like("GaiaEDR3%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia EDR3%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
-    assert len(s) == 0, f'found {len(stm)} spectra with Gaia EDR3 proper motion and no Gaia EDR3 designation in Names'
-
-    # If Gaia DR2 parallax, Gaia DR2 designation should be in Names
-    stm = except_(select([db.Parallaxes.c.source]).where(db.Parallaxes.c.reference.like("GaiaDR2%")),
-                  select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia DR2%")))
-    result = db.session.execute(stm)
-    s = result.scalars().all()
-    assert len(s) == 0, f'found {len(stm)} spectra with Gaia DR2 proper motion and no Gaia DR2 designation in Names'
+    assert len(s) == 0, f'found {len(s)} sources with Gaia EDR3 proper motion and no Gaia EDR3 designation in Names'
 
     # If Gaia EDR3 parallax, Gaia EDR3 designation should be in Names
     stm = except_(select([db.Parallaxes.c.source]).where(db.Parallaxes.c.reference.like("GaiaEDR3%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia EDR3%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
-    assert len(s) == 0, f'found {len(stm)} spectra with Gaia EDR3 proper motion and no Gaia EDR3 designation in Names'
+    assert len(s) == 0, f'found {len(s)} sources with Gaia EDR3 parallax and no Gaia EDR3 designation in Names'
 
 
 def test_spectra(db):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -253,54 +253,63 @@ def test_missions(db):
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 265, f'found {len(stm)} spectra with 2MASS designation that have no 2MASS photometry'
+
     # If 2MASS photometry, 2MASS designation should be in Names
     stm = except_(select([db.Photometry.c.source]).where(db.Photometry.c.band.like("2MASS%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("2MASS J%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 0, f'found {len(stm)} spectra with 2MASS photometry that have no 2MASS designation '
+
     # If Gaia designation in Names, Gaia photometry and astrometry should exist
     stm = except_(select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia%")),
                   select([db.Photometry.c.source]).where(db.Photometry.c.band.like("GAIA%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 1, f'found {len(stm)} spectra with Gaia designation that have no GAIA photometry'
+
     # If Gaia photometry, Gaia designation should be in Names
     stm = except_(select([db.Photometry.c.source]).where(db.Photometry.c.band.like("GAIA%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 0, f'found {len(stm)} spectra with Gaia photometry and no Gaia designation in Names'
+
     # If Wise designation in Names, Wise phot should exist
     stm = except_(select([db.Names.c.source]).where(db.Names.c.other_name.like("WISE%")),
                   select([db.Photometry.c.source]).where(db.Photometry.c.band.like("WISE%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 392, f'found {len(stm)} spectra with WISE designation that have no WISE photometry'
+
     # If Wise photometry, Wise designation should be in Names
     stm = except_(select([db.Photometry.c.source]).where(db.Photometry.c.band.like("WISE%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("WISE%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 278, f'found {len(stm)} spectra with Wise photometry and no Wise designation in Names'
+
     # If Gaia DR2 pm, Gaia DR2 designation should be in Names
     stm = except_(select([db.ProperMotions.c.source]).where(db.ProperMotions.c.reference.like("GaiaDR2%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia DR2%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 0, f'found {len(stm)} spectra with Gaia DR2 proper motion and no Gaia DR2 designation in Names'
+
     # If Gaia EDR3 pm, Gaia EDR3 designation should be in Names
     stm = except_(select([db.ProperMotions.c.source]).where(db.ProperMotions.c.reference.like("GaiaEDR3%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia EDR3%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 0, f'found {len(stm)} spectra with Gaia EDR3 proper motion and no Gaia EDR3 designation in Names'
+
     # If Gaia DR2 parallax, Gaia DR2 designation should be in Names
     stm = except_(select([db.Parallaxes.c.source]).where(db.Parallaxes.c.reference.like("GaiaDR2%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia DR2%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 0, f'found {len(stm)} spectra with Gaia DR2 proper motion and no Gaia DR2 designation in Names'
+
     # If Gaia EDR3 parallax, Gaia EDR3 designation should be in Names
     stm = except_(select([db.Parallaxes.c.source]).where(db.Parallaxes.c.reference.like("GaiaEDR3%")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia EDR3%")))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,6 +3,7 @@
 import os
 import pytest
 import sys
+
 sys.path.append('.')
 from simple.schema import *
 from astrodbkit2.astrodb import create_database, Database
@@ -175,6 +176,7 @@ def test_proper_motion_refs(db):
     t = db.query(db.ProperMotions).filter(db.ProperMotions.c.reference == ref).astropy()
     assert len(t) == 44, f'found {len(t)} proper motion reference entries for {ref}'
 
+
 def test_parallax_refs(db):
     # Test total odopted measuruments
     t = db.query(db.Parallaxes).filter(db.Parallaxes.c.adopted == 1).astropy()
@@ -242,8 +244,17 @@ def test_photometry_bands(db):
     t = db.query(db.Photometry).filter(db.Photometry.c.band == band).astropy()
     assert len(t) == 1751, f'found {len(t)} photometry measurements for {band}'
 
+
 # TODO: Tests of Gaia and 2MASS designations
-# If 2MASS designation in Names, 2MASS photometry should exist
+def test_missions(db):
+    # If 2MASS designation in Names, 2MASS photometry should exist
+    stm = except_(select([db.Names.c.source]).where(db.Names.c.other_name.like("2MASS J%")),
+                  select([db.Photometry.c.source]).where(db.Photometry.c.band.like("2MASS%")))
+    result = db.session.execute(stm)
+    s = result.scalars().all()
+    assert len(s) == 265, f'found {len(stm)} spectra with 2MASS designation that have no 2MASS photometry'
+
+
 # If 2MASS photometry, 2MASS designation should be in Names
 # If Gaia designation in Names, Gaia phot and astrometry should exist
 # If Gaia phot, Gaia designation should be in Names
@@ -278,7 +289,8 @@ def test_spectra(db):
 
     telescope = 'HST'
     instrument = 'WFC3'
-    t = db.query(db.Spectra).filter(and_(db.Spectra.c.telescope == telescope, db.Spectra.c.instrument == instrument)).astropy()
+    t = db.query(db.Spectra).filter(
+        and_(db.Spectra.c.telescope == telescope, db.Spectra.c.instrument == instrument)).astropy()
     assert len(t) == 77, f'found {len(t)} spectra from {telescope}/{instrument}'
 
     ref = 'Reid08b'
@@ -352,6 +364,7 @@ def test_Manj19_data(db):
     n_Manj19_spectra = db.query(db.Spectra).filter(db.Spectra.c.reference == pub).astropy()
     assert len(n_Manj19_spectra) == 77, f'found {len(n_Manj19_spectra)} spectra from {pub}'
 
+
 def test_Kirk19_ingest(db):
     """
     Tests for Y-dwarf data ingested from Kirkpartick+2019
@@ -376,7 +389,7 @@ def test_Kirk19_ingest(db):
     t = db.query(db.Publications).filter(db.Publications.c.publication.in_(ref_list)).astropy()
 
     if len(ref_list) != len(t):
-        missing_ref = list(set(ref_list)-set(t['name']))
+        missing_ref = list(set(ref_list) - set(t['name']))
         assert len(ref_list) == len(t), f'Missing references: {missing_ref}'
 
     # Check DOI and Bibcode values are correctly set for new references added
@@ -398,13 +411,13 @@ def test_Kirk19_ingest(db):
     ref = 'Kirk19'
     t = db.query(db.Parallaxes).filter(db.Parallaxes.c.reference == ref).astropy()
     assert len(t) == 23, f'found {len(t)} parallax entries for {ref}'
-    
-    #Test proper motions added
+
+    # Test proper motions added
     ref = 'Kirk19'
     t = db.query(db.ProperMotions).filter(db.ProperMotions.c.reference == ref).astropy()
     assert len(t) == 182, f'found {len(t)} proper motion entries for {ref}'
 
-    #Test photometry added
+    # Test photometry added
     telescope = 'Spitzer'
     t = db.query(db.Photometry).filter(db.Photometry.c.telescope == telescope).astropy()
     assert len(t) == 46, f'found {len(t)} photometry entries for {telescope}'
@@ -417,15 +430,15 @@ def test_Kirk19_ingest(db):
     t = db.query(db.Photometry).filter(db.Photometry.c.reference == ref).astropy()
     assert len(t) == 28, f'found {len(t)} photometry entries for {ref}'
 
-    #Test parallaxes added for ATLAS
+    # Test parallaxes added for ATLAS
     ref = 'Mart18'
     t = db.query(db.Parallaxes).filter(db.Parallaxes.c.reference == ref).astropy()
     assert len(t) == 15, f'found {len(t)} parallax entries for {ref}'
 
 
 def test_Best2020_ingest(db):
-    #Test for Best20a proper motions added
-    ref = 'Best20a' 
+    # Test for Best20a proper motions added
+    ref = 'Best20a'
     t = db.query(db.ProperMotions).filter(db.ProperMotions.c.reference == ref).astropy()
     assert len(t) == 348, f'found {len(t)} proper motion entries for {ref}'
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -284,7 +284,7 @@ def test_missions(db):
     s = result.scalars().all()
     assert len(s) == 278, f'found {len(stm)} spectra with Wise photometry and no Wise designation in Names'
     # If Gaia pm, Gaia designation should be in Names
-    stm = except_(select([db.ProperMotions.c.source]).where(db.Photometry.c.reference.like("GaiaDR2")),
+    stm = except_(select([db.ProperMotions.c.source]).where(db.ProperMotions.c.reference.like("GaiaDR2")),
                   select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia DR2")))
     result = db.session.execute(stm)
     s = result.scalars().all()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -254,10 +254,16 @@ def test_missions(db):
     s = result.scalars().all()
     assert len(s) == 265, f'found {len(stm)} spectra with 2MASS designation that have no 2MASS photometry'
 
+    # If 2MASS photometry, 2MASS designation should be in Names
 
-# If 2MASS photometry, 2MASS designation should be in Names
-# If Gaia designation in Names, Gaia phot and astrometry should exist
-# If Gaia phot, Gaia designation should be in Names
+    # If Gaia designation in Names, Gaia phot and astrometry should exist
+    stm = except_(select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia%")),
+                  select([db.Photometry.c.source]).where(db.Photometry.c.band.like("GAIA%")))
+    result = db.session.execute(stm)
+    s = result.scalars().all()
+    assert len(s) == 1, f'found {len(stm)} spectra with Gaia designation that have no GAIA photometry'
+
+# If Gaia photometry, Gaia designation should be in Names
 # If Gaia pm, Gaia designation should be in Names
 # If Gaia parallax, Gaia designation should be in Names
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -283,13 +283,30 @@ def test_missions(db):
     result = db.session.execute(stm)
     s = result.scalars().all()
     assert len(s) == 278, f'found {len(stm)} spectra with Wise photometry and no Wise designation in Names'
-    # If Gaia pm, Gaia designation should be in Names
-    stm = except_(select([db.ProperMotions.c.source]).where(db.ProperMotions.c.reference.like("GaiaDR2")),
-                  select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia DR2")))
+    # If Gaia DR2 pm, Gaia DR2 designation should be in Names
+    stm = except_(select([db.ProperMotions.c.source]).where(db.ProperMotions.c.reference.like("GaiaDR2%")),
+                  select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia DR2%")))
     result = db.session.execute(stm)
     s = result.scalars().all()
-    assert len(s) == 0, f'found {len(stm)} spectra with Gaia DR2 proper motions and no Gaia DR2 designation in Names'
-    # If Gaia parallax, Gaia designation should be in Names
+    assert len(s) == 0, f'found {len(stm)} spectra with Gaia DR2 proper motion and no Gaia DR2 designation in Names'
+    # If Gaia EDR3 pm, Gaia EDR3 designation should be in Names
+    stm = except_(select([db.ProperMotions.c.source]).where(db.ProperMotions.c.reference.like("GaiaEDR3%")),
+                  select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia EDR3%")))
+    result = db.session.execute(stm)
+    s = result.scalars().all()
+    assert len(s) == 0, f'found {len(stm)} spectra with Gaia EDR3 proper motion and no Gaia EDR3 designation in Names'
+    # If Gaia DR2 parallax, Gaia DR2 designation should be in Names
+    stm = except_(select([db.Parallaxes.c.source]).where(db.Parallaxes.c.reference.like("GaiaDR2%")),
+                  select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia DR2%")))
+    result = db.session.execute(stm)
+    s = result.scalars().all()
+    assert len(s) == 0, f'found {len(stm)} spectra with Gaia DR2 proper motion and no Gaia DR2 designation in Names'
+    # If Gaia EDR3 parallax, Gaia EDR3 designation should be in Names
+    stm = except_(select([db.Parallaxes.c.source]).where(db.Parallaxes.c.reference.like("GaiaEDR3%")),
+                  select([db.Names.c.source]).where(db.Names.c.other_name.like("Gaia EDR3%")))
+    result = db.session.execute(stm)
+    s = result.scalars().all()
+    assert len(s) == 0, f'found {len(stm)} spectra with Gaia EDR3 proper motion and no Gaia EDR3 designation in Names'
 
 
 def test_spectra(db):


### PR DESCRIPTION
- [x] If 2MASS designation in Names, 2MASS photometry should exist
- [x] If 2MASS photometry, 2MASS designation should be in Names
- [x] If Gaia designation in Names, Gaia phot and astrometry should exist
- [x] If Gaia phot, Gaia designation should be in Names
- [x] If Gaia pm, Gaia designation should be in Names
- [x] If Gaia parallax, Gaia designation should be in Names
- [x] Also WISE photometry
closes #198 