### PR TITLE
add original_spectrum column to spectra table

### DIFF
--- a/documentation/Spectra.md
+++ b/documentation/Spectra.md
@@ -9,6 +9,7 @@ Columns marked with an asterisk (*) may not be empty.
 |---|---|---|--------------|---|
 | *source           | Unique identifier for the source |   | String(100)  | primary and foreign: Sources.source   |
 | *spectrum         | URL of spectrum location |   | String(1000) | primary |
+| original_spectrum | URL of original spectrum location, if applicable |   | String(1000) |  |
 | local_spectrum    | Local path of spectrum   |   | String(1000) |  |
 | *regime           | Regime of the spectrum, eg Optical, Infrared, etc |  | Enumeration  | primary |
 | *telescope        | Name of telescope |  | String(30)   | foreign: Telescopes.name |
@@ -21,6 +22,9 @@ Columns marked with an asterisk (*) may not be empty.
 | comments          | Free form comments |   | String(1000) |   |
 | *reference        | Primary Reference |   | String(30)   | primary and foreign: Publications.name |
 | other_references  | Other References |   | String(100)  |   |
+
+If the spectrum provided has been modified from the author-provided one, 
+a link to the original spectrum can be provided in the `original_spectrum` column.
 
 The local_spectrum is meant to store the path to a local copy of the spectrum with an 
 environment variable to define part of the path (so it can be shared among other users). 

--- a/simple/schema.py
+++ b/simple/schema.py
@@ -205,6 +205,7 @@ class Spectra(Base):
 
     # Data
     spectrum = Column(String(1000), nullable=False)  # URL of spectrum location
+    original_spectrum = Column(String(1000)) # URL of original spectrum location, if applicable
     local_spectrum = Column(String(1000))  # local directory (via environment variable) of spectrum location
 
     # Metadata


### PR DESCRIPTION
Modifies the schema and docs for new `original_spectrum` column.
closes #266 