### PR TITLE
Versions update for generation script

### DIFF
--- a/scripts/ingests/utils.py
+++ b/scripts/ingests/utils.py
@@ -50,7 +50,7 @@ class SimpleError(Exception):
 #     sys.tracebacklimit = default_value  # revert changes
 
 
-def load_simpledb(db_file, recreatedb=True, **kwargs):
+def load_simpledb(db_file, recreatedb=True):
     # Utility function to load the database
 
     db_file_path = Path(db_file)
@@ -61,17 +61,17 @@ def load_simpledb(db_file, recreatedb=True, **kwargs):
 
     if not db_file_path.exists():
         try: # Use fancy in-memory database, if supported by astrodbkit2
-            db = Database('sqlite://', **kwargs)  # creates and connects to a temporary in-memory database
+            db = Database('sqlite://')  # creates and connects to a temporary in-memory database
             db.load_database('data/')  # loads the data from the data files into the database
             db.dump_sqlite(db_file)  # dump in-memory database to file
-            db = Database(db_connection_string, **kwargs)  # replace database object with new file version
+            db = Database(db_connection_string)  # replace database object with new file version
         except RuntimeError:
             # use in-file database
             create_database(db_connection_string)  # creates empty database based on the simple schema
-            db = Database(db_connection_string, **kwargs)  # connects to the empty database
+            db = Database(db_connection_string)  # connects to the empty database
             db.load_database('data/')  # loads the data from the data files into the database
     else:
-        db = Database(db_connection_string, **kwargs)  # if database already exists, connects to .db file
+        db = Database(db_connection_string)  # if database already exists, connects to .db file
 
     return db
 

--- a/scripts/tutorials/generate_database.py
+++ b/scripts/tutorials/generate_database.py
@@ -4,7 +4,6 @@
 import argparse
 import sys
 import os
-from astrodbkit2 import REFERENCE_TABLES
 from astrodbkit2.astrodb import create_database, Database
 sys.path.append(os.getcwd())  # hack to be able to discover simple
 from simple.schema import *
@@ -14,7 +13,7 @@ DB_PATH = 'data'
 DB_NAME = 'SIMPLE.db'
 
 # Used to overwrite AstrodbKit2 reference tables defaults
-REFERENCE_TABLES = REFERENCE_TABLES + ['Versions']
+REFERENCE_TABLES = ['Publications', 'Telescopes', 'Instruments', 'Modes', 'PhotometryFilters', 'Versions']
 
 
 def load_postgres(connection_string):

--- a/scripts/tutorials/generate_database.py
+++ b/scripts/tutorials/generate_database.py
@@ -4,6 +4,7 @@
 import argparse
 import sys
 import os
+from astrodbkit2 import REFERENCE_TABLES
 from astrodbkit2.astrodb import create_database, Database
 sys.path.append(os.getcwd())  # hack to be able to discover simple
 from simple.schema import *
@@ -13,7 +14,7 @@ DB_PATH = 'data'
 DB_NAME = 'SIMPLE.db'
 
 # Used to overwrite AstrodbKit2 reference tables defaults
-REFERENCE_TABLES = ['Publications', 'Telescopes', 'Instruments', 'Modes', 'PhotometryFilters']
+REFERENCE_TABLES = REFERENCE_TABLES + ['Versions']
 
 
 def load_postgres(connection_string):

--- a/scripts/updates/update_version.py
+++ b/scripts/updates/update_version.py
@@ -1,12 +1,11 @@
 # Script to show how to update the version number
 
 import logging
-from astrodbkit2 import REFERENCE_TABLES
 from scripts.ingests.utils import logger, load_simpledb
 
 logger.setLevel(logging.INFO)
 
-db = load_simpledb('SIMPLE.db', recreatedb=True, reference_tables=REFERENCE_TABLES+['Versions'])
+db = load_simpledb('SIMPLE.db', recreatedb=True)
 
 # Check all versions
 print(db.query(db.Versions).table())


### PR DESCRIPTION
The automatic database generation script overwrites the REFERENCE_TABLES and that causes issues (which means SIMPLE-web will not have this version). This simple update makes this more flexible.