### PR TITLE
Update gen-db.yml

### DIFF
--- a/.github/workflows/gen-db.yml
+++ b/.github/workflows/gen-db.yml
@@ -8,6 +8,7 @@ on:
   # More details on trigger events: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
   workflow_dispatch:  # manual execution
   release:
+    types: [published]
     branches: [main]
 
 jobs:


### PR DESCRIPTION
only trigger db build on *published* release, see https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release