### PR TITLE
Update tests for python 3.10

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.8
+FROM mcr.microsoft.com/devcontainers/python:3.10
 
 ENV PYTHONUNBUFFERED 1
 

--- a/.github/workflows/gen-db.yml
+++ b/.github/workflows/gen-db.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install astrodbKit2
+        pip install astrodbkit2
 
     - name: Generate sqlite (file) database
       run: |

--- a/.github/workflows/gen-db.yml
+++ b/.github/workflows/gen-db.yml
@@ -21,15 +21,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10
     
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/dr-rodriguez/AstrodbKit2
+        pip install astrodbKit2
 
     - name: Generate sqlite (file) database
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest astrodbKit2 ads
+        pip install pytest astrodbkit2 ads
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -16,17 +16,15 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Set up Python 3.8
+    - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8
+        python-version: 3.10
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install pytest
-        pip install git+https://github.com/dr-rodriguez/AstrodbKit2
-        pip install ads
+        pip install pytest astrodbKit2 ads
 
     - name: Test with pytest
       run: |


### PR DESCRIPTION
Update tests for python 3.10, also changes them to use the released version of astrodbkit2 rather than from git