### PR TITLE
Rework Telescope, Instrument, and Modes tables

### DIFF
--- a/data/Instruments.json
+++ b/data/Instruments.json
@@ -1,158 +1,158 @@
 [
     {
-        "name": "IRAC",
+        "instrument": "IRAC",
         "reference": null
     },
     {
-        "name": "WISE",
+        "instrument": "WISE",
         "reference": null
     },
     {
-        "name": "2MASS",
+        "instrument": "2MASS",
         "reference": null
     },
     {
-        "name": "Gaia",
+        "instrument": "Gaia",
         "reference": "Gaia"
     },
     {
-        "name": "SpeX",
+        "instrument": "SpeX",
         "reference": null
     },
     {
-        "name": "MagE",
+        "instrument": "MagE",
         "reference": null
     },
     {
-        "name": "GMOS-S",
+        "instrument": "GMOS-S",
         "reference": null
     },
     {
-        "name": "IRS",
+        "instrument": "IRS",
         "reference": null
     },
     {
-        "name": "FIRE",
+        "instrument": "FIRE",
         "reference": null
     },
     {
-        "name": "OSIRIS",
+        "instrument": "OSIRIS",
         "reference": null
     },
     {
-        "name": "GMOS-N",
+        "instrument": "GMOS-N",
         "reference": null
     },
     {
-        "name": "GNIRS",
+        "instrument": "GNIRS",
         "reference": null
     },
     {
-        "name": "LRIS",
+        "instrument": "LRIS",
         "reference": null
     },
     {
-        "name": "R-C Spec",
+        "instrument": "R-C Spec",
         "reference": null
     },
     {
-        "name": "GoldCam",
+        "instrument": "GoldCam",
         "reference": null
     },
     {
-        "name": "LDSS3",
+        "instrument": "LDSS3",
         "reference": null
     },
     {
-        "name": "DIS",
+        "instrument": "DIS",
         "reference": null
     },
     {
-        "name": "SINFONI",
+        "instrument": "SINFONI",
         "reference": null
     },
     {
-        "name": "ISAAC",
+        "instrument": "ISAAC",
         "reference": null
     },
     {
-        "name": "XShooter",
+        "instrument": "XShooter",
         "reference": null
     },
     {
-        "name": "WFC3",
+        "instrument": "WFC3",
         "reference": null
     },
     {
-        "name": "SofI",
+        "instrument": "SofI",
         "reference": null
     },
     {
-        "name": "NIRSPEC",
+        "instrument": "NIRSPEC",
         "reference": null
     },
     {
-        "name": "SDSS",
+        "instrument": "SDSS",
         "reference": null
     },
     {
-        "name": "ACAM",
+        "instrument": "ACAM",
         "reference": "ACAM"
     },
     {
-        "name": "VIRCAM",
+        "instrument": "VIRCAM",
         "reference": "VIRCAM"
     },
     {
-        "name": "DENIS",
+        "instrument": "DENIS",
         "reference": null
     },
     {
-        "name": "SOI",
+        "instrument": "SOI",
         "reference": null
     },
     {
-        "name": "SMARTS",
+        "instrument": "SMARTS",
         "reference": null
     },
     {
-        "name": "UFTI",
+        "instrument": "UFTI",
         "reference": null
     },
     {
-        "name": "NICMOS1",
+        "instrument": "NICMOS1",
         "reference": null
     },
     {
-        "name": "GALEX",
+        "instrument": "GALEX",
         "reference": null
     },
     {
-        "name": "MIPS",
+        "instrument": "MIPS",
         "reference": null
     },
     {
-        "name": "WFCAM",
+        "instrument": "WFCAM",
         "reference": null
     },
     {
-        "name": "PS1",
+        "instrument": "PS1",
         "reference": null
     },
     {
-        "name": "UKIDSS",
+        "instrument": "UKIDSS",
         "reference": null
     },
     {
-        "name": "Unknown",
+        "instrument": "Unknown",
         "reference": null
     },
     {
-        "name": "NSFCam",
+        "instrument": "NSFCam",
         "reference": null
     },
     {
-        "name": "NACO",
+        "instrument": "NACO",
         "reference": null
     }
 ]

--- a/data/Modes.json
+++ b/data/Modes.json
@@ -1,66 +1,66 @@
 [
     {
-        "name": "Prism",
+        "mode": "Prism",
         "instrument": "SpeX",
         "telescope": "IRTF"
     },
     {
-        "name": "Echelle",
+        "mode": "Echelle",
         "instrument": "MagE",
         "telescope": "Magellan II Clay"
     },
     {
-        "name": "SXD",
+        "mode": "SXD",
         "instrument": "OSIRIS",
         "telescope": "CTIO 1.5m"
     },
     {
-        "name": "LL",
+        "mode": "LL",
         "instrument": "IRS",
         "telescope": "Spitzer"
     },
     {
-        "name": "Echelle",
+        "mode": "Echelle",
         "instrument": "FIRE",
         "telescope": "Magellan I Baade"
     },
     {
-        "name": "SL",
+        "mode": "SL",
         "instrument": "IRS",
         "telescope": "Spitzer"
     },
     {
-        "name": "Prism",
+        "mode": "Prism",
         "instrument": "GMOS-S",
         "telescope": "Gemini South"
     },
     {
-        "name": "Prism",
+        "mode": "Prism",
         "instrument": "GMOS-N",
         "telescope": "Gemini North"
     },
     {
-        "name": "SXD",
+        "mode": "SXD",
         "instrument": "GNIRS",
         "telescope": "Gemini North"
     },
     {
-        "name": "SXD",
+        "mode": "SXD",
         "instrument": "SpeX",
         "telescope": "IRTF"
     },
     {
-        "name": "SW LRes",
+        "mode": "SW LRes",
         "instrument": "ISAAC",
         "telescope": "ESO VLT U3"
     },
     {
-        "name": "Echelle",
+        "mode": "Echelle",
         "instrument": "XShooter",
         "telescope": "ESO VLT"
     },
     {
-        "name": "G141 grism",
+        "mode": "G141 grism",
         "instrument": "WFC3",
         "telescope": "HST"
     }

--- a/data/Telescopes.json
+++ b/data/Telescopes.json
@@ -1,146 +1,146 @@
 [
     {
-        "name": "WISE",
+        "telescope": "WISE",
         "reference": null
     },
     {
-        "name": "Spitzer",
+        "telescope": "Spitzer",
         "reference": null
     },
     {
-        "name": "2MASS",
+        "telescope": "2MASS",
         "reference": null
     },
     {
-        "name": "Gaia",
+        "telescope": "Gaia",
         "reference": "Gaia"
     },
     {
-        "name": "IRTF",
+        "telescope": "IRTF",
         "reference": null
     },
     {
-        "name": "Magellan II Clay",
+        "telescope": "Magellan II Clay",
         "reference": null
     },
     {
-        "name": "CTIO 1.5m",
+        "telescope": "CTIO 1.5m",
         "reference": null
     },
     {
-        "name": "Magellan I Baade",
+        "telescope": "Magellan I Baade",
         "reference": null
     },
     {
-        "name": "Gemini South",
+        "telescope": "Gemini South",
         "reference": null
     },
     {
-        "name": "Gemini North",
+        "telescope": "Gemini North",
         "reference": null
     },
     {
-        "name": "Keck I",
+        "telescope": "Keck I",
         "reference": null
     },
     {
-        "name": "CTIO 4m",
+        "telescope": "CTIO 4m",
         "reference": null
     },
     {
-        "name": "KPNO 2.1m",
+        "telescope": "KPNO 2.1m",
         "reference": null
     },
     {
-        "name": "KPNO 4m",
+        "telescope": "KPNO 4m",
         "reference": null
     },
     {
-        "name": "ARC 3.5m",
+        "telescope": "ARC 3.5m",
         "reference": null
     },
     {
-        "name": "ESO VLT U2",
+        "telescope": "ESO VLT U2",
         "reference": null
     },
     {
-        "name": "ESO VLT U3",
+        "telescope": "ESO VLT U3",
         "reference": null
     },
     {
-        "name": "ESO VLT",
+        "telescope": "ESO VLT",
         "reference": null
     },
     {
-        "name": "HST",
+        "telescope": "HST",
         "reference": null
     },
     {
-        "name": "GALEX",
+        "telescope": "GALEX",
         "reference": null
     },
     {
-        "name": "CFHT",
+        "telescope": "CFHT",
         "reference": null
     },
     {
-        "name": "Keck II",
+        "telescope": "Keck II",
         "reference": null
     },
     {
-        "name": "Pan-STARRS 1",
+        "telescope": "Pan-STARRS 1",
         "reference": null
     },
     {
-        "name": "UKIRT",
+        "telescope": "UKIRT",
         "reference": null
     },
     {
-        "name": "NTT",
+        "telescope": "NTT",
         "reference": null
     },
     {
-        "name": "GTC",
+        "telescope": "GTC",
         "reference": null
     },
     {
-        "name": "WHT",
+        "telescope": "WHT",
         "reference": null
     },
     {
-        "name": "VISTA",
+        "telescope": "VISTA",
         "reference": "VISTA"
     },
     {
-        "name": "Sloan",
+        "telescope": "Sloan",
         "reference": null
     },
     {
-        "name": "DENIS",
+        "telescope": "DENIS",
         "reference": null
     },
     {
-        "name": "Soar",
+        "telescope": "Soar",
         "reference": null
     },
     {
-        "name": "CTIO",
+        "telescope": "CTIO",
         "reference": null
     },
     {
-        "name": "Pan-STARRS",
+        "telescope": "Pan-STARRS",
         "reference": null
     },
     {
-        "name": "Unknown",
+        "telescope": "Unknown",
         "reference": null
     },
     {
-        "name": "ESO VLT U4",
+        "telescope": "ESO VLT U4",
         "reference": null
     },
     {
-        "name": "MKO",
+        "telescope": "MKO",
         "reference": null
     }
 ]

--- a/documentation/Instruments.md
+++ b/documentation/Instruments.md
@@ -2,10 +2,11 @@
 
 The Instruments table contains names and references for instruments referred to in other tables.
 Entries must exist in the Instruments table prior to inserting data that refer to it.
-The *name* of an instrument is required to be unique. 
+The *instrument* column is required to be unique. 
 Columns marked with an asterisk (*) may not be empty.
 
-| Column Name | Description  | Unit  | Data Type | Key Type  |
-|---|---|---|---|---|
-| *name      | Unique name for the instrument |   | String(30)  | primary   |
-| reference | Reference to the instrument |   | String(30) | foreign: Publications.name |
+| Column Name | Description                     | Unit  | Data Type | Key Type  |
+|-------------|---------------------------------|---|---|---|
+| *instrument | Unique name for the instrument  |   | String(30)  | primary   |
+| description | Long name of instrument |   | String(1000) |    |
+| reference   | Reference to the instrument |   | String(30) | foreign: Publications.name |

--- a/documentation/Publications.md
+++ b/documentation/Publications.md
@@ -10,7 +10,7 @@ Columns marked with an asterisk (*) may not be empty.
 | *reference  | Unique identifier for the publication |   | String(30)  | primary   |
 | bibcode     | ADS Bibcode entry |   | String(100)  |    |
 | doi         | Document Object Identifier (DOI) |   | String(100)  |    |
-| description | Publication description, optional |   | String(1000)  |    |
+| description | Publication description |   | String(1000)  |    |
 
 ## Notes
 -  `Reference` is typically a six letter string consisting of first four letters of first author name and two digit year. 

--- a/documentation/Telescopes.md
+++ b/documentation/Telescopes.md
@@ -2,10 +2,11 @@
 
 The Telescopes table contains names and references for telescopes referred to in other tables.
 Entries must exist in the Telescopes table prior to inserting data that refer to it.
-The *name* of a telescope is required to be unique.
+The *telescope* column is required to be unique.
 Columns marked with an asterisk (*) may not be empty.
 
-| Column Name | Description  | Unit  | Data Type | Key Type  |
-|---|---|---|---|---|
-| *name      | Unique name for the telescope |   | String(30)  | primary   |
-| *reference | Reference to the telescope |   | String(30) | foreign: Publications.name |
+| Column Name | Description                    | Unit  | Data Type    | Key Type  |
+|------------|--------------------------------|---|--------------|---|
+| *telescope | Unique name for the telescope  |   | String(30)   | primary   |
+| description | Long name of telescope |   | String(1000) |    |
+| reference  | Reference to the telescope     |   | String(30)   | foreign: Publications.name |

--- a/scripts/ingests/ingest_utils.py
+++ b/scripts/ingests/ingest_utils.py
@@ -1288,10 +1288,10 @@ def ingest_instrument(db, telescope=None, instrument=None, mode=None):
     logger.info(msg_search)
 
     # Search for the inputs in the database
-    telescope_db = db.query(db.Telescopes).filter(db.Telescopes.c.name == telescope).table()
-    instrument_db = db.query(db.Instruments).filter(db.Instruments.c.name == instrument).table()
+    telescope_db = db.query(db.Telescopes).filter(db.Telescopes.c.telescope == telescope).table()
+    instrument_db = db.query(db.Instruments).filter(db.Instruments.c.instrument == instrument).table()
     if mode is not None:
-        mode_db = db.query(db.Modes).filter(and_(db.Modes.c.name == mode,
+        mode_db = db.query(db.Modes).filter(and_(db.Modes.c.mode == mode,
                                                  db.Modes.c.instrument == instrument,
                                                  db.Modes.c.telescope == telescope)).table()
 
@@ -1301,7 +1301,7 @@ def ingest_instrument(db, telescope=None, instrument=None, mode=None):
         return
 
     if telescope is not None and len(telescope_db) == 0:
-        telescope_add = [{'name': telescope}]
+        telescope_add = [{'telescope': telescope}]
         try:
             with db.engine.connect() as conn:
                 conn.execute(db.Telescopes.insert().values(telescope_add))
@@ -1319,7 +1319,7 @@ def ingest_instrument(db, telescope=None, instrument=None, mode=None):
                 raise SimpleError(msg + '\n' + str(e))
 
     if instrument is not None and len(instrument_db) == 0:
-        instrument_add = [{'name': instrument}]
+        instrument_add = [{'instrument': instrument}]
         try:
             with db.engine.connect() as conn:
                 conn.execute(db.Instruments.insert().values(instrument_add))
@@ -1337,7 +1337,7 @@ def ingest_instrument(db, telescope=None, instrument=None, mode=None):
                 raise SimpleError(msg + '\n' + str(e))
 
     if mode is not None and len(mode_db) == 0:
-        mode_add = [{'name': mode,
+        mode_add = [{'mode': mode,
                      'instrument': instrument,
                      'telescope': telescope}]
         try:

--- a/simple/schema.py
+++ b/simple/schema.py
@@ -241,7 +241,7 @@ class Spectra(Base):
                     primary_key=True)  # eg, Optical, Infrared, etc
     telescope = Column(String(30), ForeignKey(Telescopes.telescope))
     instrument = Column(String(30), ForeignKey(Instruments.instrument))
-    mode = Column(String(30), ForeignKey(Modes.mode))  # eg, Prism, Echelle, etc
+    mode = Column(String(30))  # eg, Prism, Echelle, etc
     observation_date = Column(DateTime, primary_key=True)
 
     # Common metadata

--- a/simple/schema.py
+++ b/simple/schema.py
@@ -25,21 +25,24 @@ class Publications(Base):
 
 class Telescopes(Base):
     __tablename__ = 'Telescopes'
-    name = Column(String(30), primary_key=True, nullable=False)
+    telescope = Column(String(30), primary_key=True, nullable=False)
+    description = Column(String(1000))
     reference = Column(String(30), ForeignKey('Publications.reference', onupdate='cascade'))
 
 
 class Instruments(Base):
     __tablename__ = 'Instruments'
-    name = Column(String(30), primary_key=True, nullable=False)
+    instrument = Column(String(30), primary_key=True, nullable=False)
+    description = Column(String(1000))
     reference = Column(String(30), ForeignKey('Publications.reference', onupdate='cascade'))
 
 
 class Modes(Base):
     __tablename__ = 'Modes'
     name = Column(String(30), primary_key=True, nullable=False)
-    instrument = Column(String(30), ForeignKey('Instruments.name', onupdate='cascade'), primary_key=True)
-    telescope = Column(String(30), ForeignKey('Telescopes.name', onupdate='cascade'), primary_key=True)
+    instrument = Column(String(30), ForeignKey('Instruments.instrument', onupdate='cascade'), primary_key=True)
+    telescope = Column(String(30), ForeignKey('Telescopes.telescope', onupdate='cascade'), primary_key=True)
+    description = Column(String(1000))
 
 
 class Parameters(Base):
@@ -56,8 +59,8 @@ class PhotometryFilters(Base):
     """
     __tablename__ = 'PhotometryFilters'
     band = Column(String(30), primary_key=True, nullable=False)  # of the form instrument.filter (see SVO)
-    instrument = Column(String(30), ForeignKey('Instruments.name', onupdate='cascade'), primary_key=True)
-    telescope = Column(String(30), ForeignKey('Telescopes.name', onupdate='cascade'), primary_key=True)
+    instrument = Column(String(30), ForeignKey('Instruments.instrument', onupdate='cascade'), primary_key=True)
+    telescope = Column(String(30), ForeignKey('Telescopes.telescope', onupdate='cascade'), primary_key=True)
     effective_wavelength = Column(Float, nullable=False)
     width = Column(Float)
 
@@ -236,9 +239,9 @@ class Spectra(Base):
     regime = Column(Enum(Regime, create_constraint=True, values_callable=lambda x: [e.value for e in x],
                          native_enum=False),
                     primary_key=True)  # eg, Optical, Infrared, etc
-    telescope = Column(String(30), ForeignKey(Telescopes.name))
-    instrument = Column(String(30), ForeignKey(Instruments.name))
-    mode = Column(String(30))  # eg, Prism, Echelle, etc
+    telescope = Column(String(30), ForeignKey(Telescopes.telescope))
+    instrument = Column(String(30), ForeignKey(Instruments.instrument))
+    mode = Column(String(30), ForeignKey(Modes.mode))  # eg, Prism, Echelle, etc
     observation_date = Column(DateTime, primary_key=True)
 
     # Common metadata
@@ -248,7 +251,7 @@ class Spectra(Base):
 
     # Foreign key constraints for telescope, instrument, mode; all handled via reference to Modes table
     __table_args__ = (ForeignKeyConstraint([telescope, instrument, mode],
-                                           [Modes.telescope, Modes.instrument, Modes.name],
+                                           [Modes.telescope, Modes.instrument, Modes.mode],
                                            onupdate="cascade"),
                       {})
 

--- a/simple/schema.py
+++ b/simple/schema.py
@@ -39,7 +39,7 @@ class Instruments(Base):
 
 class Modes(Base):
     __tablename__ = 'Modes'
-    name = Column(String(30), primary_key=True, nullable=False)
+    mode = Column(String(30), primary_key=True, nullable=False)
     instrument = Column(String(30), ForeignKey('Instruments.instrument', onupdate='cascade'), primary_key=True)
     telescope = Column(String(30), ForeignKey('Telescopes.telescope', onupdate='cascade'), primary_key=True)
     description = Column(String(1000))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -201,46 +201,46 @@ def test_ingest_instrument(db):
 
     #  test adding just telescope
     ingest_instrument(db, telescope='test')
-    telescope_db = db.query(db.Telescopes).filter(db.Telescopes.c.name == 'test').table()
+    telescope_db = db.query(db.Telescopes).filter(db.Telescopes.c.telescope == 'test').table()
     assert len(telescope_db) == 1
-    assert telescope_db['name'][0] == 'test'
+    assert telescope_db['telescope'][0] == 'test'
 
     #  test adding telescope and instrument
     tel_test = 'test2'
     inst_test = 'test3'
     ingest_instrument(db, telescope=tel_test, instrument=inst_test)
-    telescope_db = db.query(db.Telescopes).filter(db.Telescopes.c.name == tel_test).table()
-    instrument_db = db.query(db.Instruments).filter(db.Instruments.c.name == inst_test).table()
+    telescope_db = db.query(db.Telescopes).filter(db.Telescopes.c.telescope == tel_test).table()
+    instrument_db = db.query(db.Instruments).filter(db.Instruments.c.instrument == inst_test).table()
     assert len(telescope_db) == 1
-    assert telescope_db['name'][0] == tel_test
+    assert telescope_db['telescope'][0] == tel_test
     assert len(instrument_db) == 1
-    assert instrument_db['name'][0] == inst_test
+    assert instrument_db['instrument'][0] == inst_test
 
     #  test adding new telescope, instrument, and mode
     tel_test = 'test4'
     inst_test = 'test5'
     mode_test = 'test6'
     ingest_instrument(db, telescope=tel_test, instrument=inst_test, mode=mode_test)
-    telescope_db = db.query(db.Telescopes).filter(db.Telescopes.c.name == tel_test).table()
-    instrument_db = db.query(db.Instruments).filter(db.Instruments.c.name == inst_test).table()
-    mode_db = db.query(db.Modes).filter(db.Modes.c.name == mode_test).table()
+    telescope_db = db.query(db.Telescopes).filter(db.Telescopes.c.telescope == tel_test).table()
+    instrument_db = db.query(db.Instruments).filter(db.Instruments.c.instrument == inst_test).table()
+    mode_db = db.query(db.Modes).filter(db.Modes.c.mode == mode_test).table()
     assert len(telescope_db) == 1
-    assert telescope_db['name'][0] == tel_test
+    assert telescope_db['telescope'][0] == tel_test
     assert len(instrument_db) == 1
-    assert instrument_db['name'][0] == inst_test
+    assert instrument_db['instrument'][0] == inst_test
     assert len(mode_db) == 1
-    assert mode_db['name'][0] == mode_test
+    assert mode_db['mode'][0] == mode_test
 
     #  test adding common mode name for new telescope, instrument
     tel_test = 'test4'
     inst_test = 'test5'
     mode_test = 'Prism'
     ingest_instrument(db, telescope=tel_test, instrument=inst_test, mode=mode_test)
-    mode_db = db.query(db.Modes).filter(and_(db.Modes.c.name == mode_test,
+    mode_db = db.query(db.Modes).filter(and_(db.Modes.c.mode == mode_test,
                                              db.Modes.c.instrument == inst_test,
                                              db.Modes.c.telescope == tel_test)).table()
     assert len(mode_db) == 1
-    assert mode_db['name'][0] == mode_test
+    assert mode_db['mode'][0] == mode_test
 
     #  TESTS WHICH SHOULD FAIL
     #  test with no variables provided


### PR DESCRIPTION
Renaming columns names from `name` to `telescope`, `instrument`, and `mode`.
Link to relevant issue: Closes #294. 

Todo:
- [x] includes script used for ingest
- [x] includes modified JSON files
- [x] tests passing
- [x] ~~Update the Versions table~~ - waiting on more changes
- [x] Update the documentation
