### PR TITLE
Ingest of JWST spectra for VHS 1256b

### DIFF
--- a/data/2mass_j12560183-1257276.json
+++ b/data/2mass_j12560183-1257276.json
@@ -159,6 +159,19 @@
     ],
     "Spectra": [
         {
+            "spectrum": "https://bdnyc.s3.amazonaws.com/JWST/MIRI/VHS1256b_MIRI.fits",
+            "original_spectrum": "https://bdnyc.s3.amazonaws.com/JWST/VHS1256b_V2.txt",
+            "local_spectrum": null,
+            "regime": "mir",
+            "telescope": "JWST",
+            "instrument": "MIRI",
+            "mode": "MRS",
+            "observation_date": "2022-07-05T00:00:00",
+            "comments": null,
+            "reference": "Mile23",
+            "other_references": null
+        },
+        {
             "spectrum": "https://bdnyc.s3.amazonaws.com/nir_spectra/vhs1256b_nir_SOFI.fits",
             "original_spectrum": "https://bdnyc.s3.amazonaws.com/vhs1256b_optnir_werrors.txt",
             "local_spectrum": null,
@@ -182,6 +195,19 @@
             "observation_date": "2016-06-19T00:00:00",
             "comments": null,
             "reference": "Mile18",
+            "other_references": null
+        },
+        {
+            "spectrum": "https://bdnyc.s3.amazonaws.com/JWST/NIRSpec/VHS1256b_NIR.fits",
+            "original_spectrum": "https://bdnyc.s3.amazonaws.com/JWST/VHS1256b_V2.txt",
+            "local_spectrum": null,
+            "regime": "nir",
+            "telescope": "JWST",
+            "instrument": "NIRSpec",
+            "mode": "IFU",
+            "observation_date": "2022-07-05T00:00:00",
+            "comments": null,
+            "reference": "Mile23",
             "other_references": null
         },
         {

--- a/data/Instruments.json
+++ b/data/Instruments.json
@@ -348,5 +348,75 @@
         "telescope": "Spitzer",
         "description": null,
         "reference": null
+    },
+    {
+        "instrument": "NIRSpec",
+        "mode": "IFU",
+        "telescope": "JWST",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "NIRSpec",
+        "mode": "MOS",
+        "telescope": "JWST",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "NIRSpec",
+        "mode": "BOTS",
+        "telescope": "JWST",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "MIRI",
+        "mode": "IFU",
+        "telescope": "JWST",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "MIRI",
+        "mode": "MRS",
+        "telescope": "JWST",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "MIRI",
+        "mode": "LRS",
+        "telescope": "JWST",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "NIRCam",
+        "mode": "TSO",
+        "telescope": "JWST",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "NIRCam",
+        "mode": "WFSS",
+        "telescope": "JWST",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "NIRISS",
+        "mode": "WFSS",
+        "telescope": "JWST",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "NIRISS",
+        "mode": "SOSS",
+        "telescope": "JWST",
+        "description": null,
+        "reference": null
     }
 ]

--- a/data/Publications.json
+++ b/data/Publications.json
@@ -6910,5 +6910,11 @@
         "bibcode": "",
         "doi": "",
         "description": "P. Pinfield and M. Gromadzki, private communication 2014"
+    },
+    {
+        "reference": "Mile23",
+        "bibcode": "2023ApJ...946L...6M",
+        "doi": "10.3847/2041-8213/acb04a",
+        "description": "The JWST Early-release Science Program for Direct Observations of Exoplanetary Systems II: A 1 to 20 \u03bcm Spectrum of the Planetary-mass Companion VHS 1256-1257 b"
     }
 ]

--- a/data/Telescopes.json
+++ b/data/Telescopes.json
@@ -178,5 +178,10 @@
         "telescope": "MKO",
         "description": null,
         "reference": null
+    },
+    {
+        "telescope": "JWST",
+        "description": "James Webb Space Telescope",
+        "reference": null
     }
 ]

--- a/data/Versions.json
+++ b/data/Versions.json
@@ -36,8 +36,14 @@
         "description": "Schema rework"
     },
     {
-        "version": "latest",
+        "version": "2023.2",
         "start_date": "2023-07-11",
+        "end_date": "2023-07-25",
+        "description": "Added JWST spectra for VHS 1256b"
+    },
+    {
+        "version": "latest",
+        "start_date": "2023-07-25",
         "end_date": null,
         "description": "Version in development"
     }

--- a/scripts/ingests/ingest_VHS1256b_JWST.py
+++ b/scripts/ingests/ingest_VHS1256b_JWST.py
@@ -1,0 +1,83 @@
+"""
+Basic script for ingesting JWST spectrum for VHS1256b
+"""
+
+# pylint: disable=no-member
+
+import logging
+from datetime import datetime
+from scripts.ingests.utils import logger, load_simpledb, ingest_publication
+
+SAVE_DB = True  # save the data files in addition to modifying the .db file
+RECREATE_DB = True  # recreates the .db file from the data files
+
+logger.setLevel(logging.DEBUG)
+
+db = load_simpledb('SIMPLE.db', recreatedb=RECREATE_DB)
+
+# Find identifier
+source_data = db.search_object('VHS 1256')
+source = source_data[0]['source']
+
+# Confirm telescope/instrument exists
+t = db.query(db.Telescopes).filter(db.Telescopes.c.telescope == 'JWST').table()
+if len(t) == 0:
+    # Ingest
+    telescope_data = [{'telescope': 'JWST', 'description': 'James Webb Space Telescope'}]
+    instruments_data = [
+        {'instrument': 'NIRSpec', 'mode': 'IFU', 'telescope': 'JWST'},
+        {'instrument': 'NIRSpec', 'mode': 'MOS', 'telescope': 'JWST'},
+        {'instrument': 'NIRSpec', 'mode': 'BOTS', 'telescope': 'JWST'},
+        {'instrument': 'MIRI', 'mode': 'IFU', 'telescope': 'JWST'},
+        {'instrument': 'MIRI', 'mode': 'MRS', 'telescope': 'JWST'},
+        {'instrument': 'MIRI', 'mode': 'LRS', 'telescope': 'JWST'},
+        {'instrument': 'NIRCam', 'mode': 'TSO', 'telescope': 'JWST'},
+        {'instrument': 'NIRCam', 'mode': 'WFSS', 'telescope': 'JWST'},
+        {'instrument': 'NIRISS', 'mode': 'WFSS', 'telescope': 'JWST'},
+        {'instrument': 'NIRISS', 'mode': 'SOSS', 'telescope': 'JWST'},
+    ]
+    with db.engine.connect() as conn:
+        conn.execute(db.Telescopes.insert().values(telescope_data))
+        conn.execute(db.Instruments.insert().values(instruments_data))
+        conn.commit()
+
+# Ingest publication
+ingest_publication(db, doi='10.3847/2041-8213/acb04a')
+ref_data = db.query(db.Publications).filter(db.Publications.c.doi == '10.3847/2041-8213/acb04a').table()
+reference = ref_data[0]['reference']
+
+# Prepare spectra data to ingest
+spectra_data = [
+    {'source': source,
+     'spectrum': 'https://bdnyc.s3.amazonaws.com/JWST/NIRSpec/VHS1256b_NIR.fits',
+     'original_spectrum': 'https://bdnyc.s3.amazonaws.com/JWST/VHS1256b_V2.txt',
+     'telescope': 'JWST',
+     'instrument': 'NIRSpec',
+     'mode': 'IFU',
+     'regime': 'nir',
+     'observation_date': datetime.fromisoformat('2022-07-05'),
+     'reference': reference
+     },
+    {'source': source,
+     'spectrum': 'https://bdnyc.s3.amazonaws.com/JWST/MIRI/VHS1256b_MIRI.fits',
+     'original_spectrum': 'https://bdnyc.s3.amazonaws.com/JWST/VHS1256b_V2.txt',
+     'telescope': 'JWST',
+     'instrument': 'MIRI',
+     'mode': 'MRS',
+     'regime': 'mir',
+     'observation_date': datetime.fromisoformat('2022-07-05'),
+     'reference': reference
+     },
+]
+
+# Actually ingest spectra
+with db.engine.connect() as conn:
+    conn.execute(db.Spectra.insert().values(spectra_data))
+    conn.commit()
+
+# Check contents
+_ = db.inventory(source, pretty_print=True)
+
+# Save the files to disk
+if SAVE_DB:
+    db.save_database(directory='data/')

--- a/scripts/updates/update_version.py
+++ b/scripts/updates/update_version.py
@@ -15,11 +15,14 @@ print(db.query(db.Versions).table())
 
 # Add new version, add new entries as appropriate
 # Note that start_date and end_date are strings of the date in format YYYY-MM-DD
-data = [{'version': '2022.4',
-         'start_date': '2022-10-14',
-         'end_date': '2022-10-16',
-         'description': ''}]
-db.Versions.insert().execute(data)
+data = [{'version': '2023.2',
+         'start_date': '2023-07-11',
+         'end_date': '2023-07-25',
+         'description': 'Added JWST spectra for VHS 1256b'}]
+with db.engine.connect() as conn:
+    conn.execute(db.Versions.insert().values(data))
+    conn.commit()
+
 
 # Fetch data of latest release
 latest_date = db.query(db.Versions.c.end_date).order_by(db.Versions.c.end_date.desc()).limit(1).table()
@@ -27,11 +30,15 @@ latest_date = latest_date['end_date'][0]
 
 latest = db.query(db.Versions).filter(db.Versions.c.version == 'latest').count()
 if latest == 1:
-    db.Versions.delete().where(db.Versions.c.version == 'latest').execute()
+    with db.engine.connect() as conn:
+        conn.execute(db.Versions.delete().where(db.Versions.c.version == 'latest'))
+        conn.commit()
 
 # Add latest
 data = [{'version': 'latest', 'start_date': latest_date, 'description': 'Version in development'}]
-db.Versions.insert().execute(data)
+with db.engine.connect() as conn:
+    conn.execute(db.Versions.insert().values(data))
+    conn.commit()
 
 print(db.query(db.Versions).table())
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -322,11 +322,11 @@ def test_spectra(db):
 
     regime = 'nir'
     t = db.query(db.Spectra).filter(db.Spectra.c.regime == regime).astropy()
-    assert len(t) == 458, f'found {len(t)} spectra in the {regime} regime'
+    assert len(t) == 459, f'found {len(t)} spectra in the {regime} regime'
 
     regime = 'mir'
     t = db.query(db.Spectra).filter(db.Spectra.c.regime == regime).astropy()
-    assert len(t) == 203, f'found {len(t)} spectra in the {regime} regime'
+    assert len(t) == 204, f'found {len(t)} spectra in the {regime} regime'
 
     telescope = 'IRTF'
     t = db.query(db.Spectra).filter(db.Spectra.c.telescope == telescope).astropy()


### PR DESCRIPTION
Short description: Adds JWST spectra (and telescope, instrument, publications) for VHS 1256b

Link to relevant issue: Closes #387 

For data ingests:
- [x] includes script used for ingest
- [x] includes modified JSON files
- [x] Add new tests
- [x] Update the Versions table
