### PR TITLE
Create missing_data issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/missing_data
+++ b/.github/ISSUE_TEMPLATE/missing_data
@@ -1,18 +1,18 @@
 ---
 name: Missing Data
 about: Report missing data from the database
-title: 'Additional data ingest request from: <publication>'
+title: 'Data ingest request from: <publication>'
 labels: data ingestion
 assignees: ''
 
 ---
 
-Please provide as much information about what is missing, as possible. 
+Please provide as much information as possible about the data you think should be added. 
 
 # Source/survey/catalogue name(s)
 
 # SIMBAD/CDS/Vizier link to data source(s), if available
 
-# What data is missing?
+# What data needs to be added?
 
-# Reference paper or publically accessible link (e.g. NASA ADS/ArXiV) to the missing publication
+# Reference(s) paper for the data

--- a/.github/ISSUE_TEMPLATE/missing_data
+++ b/.github/ISSUE_TEMPLATE/missing_data
@@ -1,0 +1,18 @@
+---
+name: Missing Data
+about: Report missing data from the database
+title: 'Additional data ingest request from: <publication>'
+labels: data ingestion
+assignees: ''
+
+---
+
+Please provide as much information about what is missing, as possible. 
+
+# Source/survey/catalogue name(s)
+
+# SIMBAD/CDS/Vizier link to data source(s), if available
+
+# What data is missing?
+
+# Reference paper or publically accessible link (e.g. NASA ADS/ArXiV) to the missing publication


### PR DESCRIPTION
For example on the solo results page on the website, in case anything beyond an individual source is missing (e.g. RVs from Author+YY)
