### PR TITLE
Adding validation for parallaxes and fixing ParallaxView

### DIFF
--- a/simple/schema.py
+++ b/simple/schema.py
@@ -241,6 +241,12 @@ class Parallaxes(Base):
         primary_key=True,
     )
 
+    @validates("parallax")
+    def validate_value(self, key, value):
+        if value is None or value < 0:
+            raise ValueError(f"{key} not allowed to be 0 or lower")
+        return value
+
 
 class ProperMotions(Base):
     # Table to store proper motions, in milliarcseconds per year
@@ -445,7 +451,7 @@ ParallaxView = view(
         Parallaxes.reference.label("reference"),
     )
     .select_from(Parallaxes)
-    .where(sa.and_(Parallaxes.adopted is True, Parallaxes.parallax > 0)),
+    .where(sa.and_(Parallaxes.adopted == 1, Parallaxes.parallax > 0)),
 )
 
 PhotometryView = view(

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,13 +1,14 @@
 # Test to verify database integrity
 # database object 'db' defined in conftest.py
 import pytest
-from sqlalchemy import func, and_
-from astropy.table import unique
-from astropy import units as u
-from astroquery.simbad import Simbad
-from astrodbkit2.utils import _name_formatter
 from astrodbkit2.astrodb import or_
-# from simple.schema import ParallaxView  # , PhotometryView
+from astrodbkit2.utils import _name_formatter
+from astropy import units as u
+from astropy.table import unique
+from astroquery.simbad import Simbad
+from sqlalchemy import and_, func
+
+from simple.schema import ParallaxView  # , PhotometryView
 
 
 def test_reference_uniqueness(db):
@@ -703,7 +704,6 @@ def test_special_characters(db):
                     assert all(check), f"{char} in {table_name}"
 
 
-@pytest.mark.skip(reason="ParallaxView not working")
 def test_database_views(db):
     # Tests to verify views exist and work as intended
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from simple.schema import PhotometryFilters, Publications, Sources
+from simple.schema import Parallaxes, PhotometryFilters, Publications, Sources
 
 
 def schema_tester(table, values, error_state):
@@ -47,3 +47,14 @@ def test_sources(values, error_state):
 def test_publications(values, error_state):
     """Validating Publications"""
     schema_tester(Publications, values, error_state)
+
+
+@pytest.mark.parametrize("values, error_state",
+                         [
+                             ({"parallax": 0.1}, None),
+                             ({"parallax": -999}, ValueError),
+                             ({"parallax": None}, ValueError),
+                          ])
+def test_parallaxes(values, error_state):
+    """Validating Parallaxes"""
+    schema_tester(Parallaxes, values, error_state)


### PR DESCRIPTION
This adds validation in Parallaxes to prevent negative or 0 for the parallax value.
This also updates the ParallaxView to work again. At some point the check `is True` stopped working and we need to use `== 1`. The database view tests have been re-enabled.

Closes #474