### PR TITLE
2MASS 0415 Ingest

### DIFF
--- a/data/reference/Instruments.json
+++ b/data/reference/Instruments.json
@@ -456,9 +456,9 @@
     },
     {
         "instrument": "IRC",
-        "mode": "NIR",
+        "mode": "IRC04",
         "telescope": "AKARI",
         "description": null,
-        "reference": "Mura07"
+        "reference": "Onak07"
     }
 ]

--- a/data/reference/Instruments.json
+++ b/data/reference/Instruments.json
@@ -453,5 +453,26 @@
         "telescope": "JWST",
         "description": "Fixed Slit",
         "reference": null
+    },
+    {
+        "instrument": "IRC",
+        "mode": "Missing",
+        "telescope": "AKARI",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "IRC",
+        "mode": "NIR",
+        "telescope": "AKARI",
+        "description": null,
+        "reference": null
+    },
+    {
+        "instrument": "LRIS",
+        "mode": "Missing",
+        "telescope": "KECK I",
+        "description": null,
+        "reference": null
     }
 ]

--- a/data/reference/Instruments.json
+++ b/data/reference/Instruments.json
@@ -456,23 +456,9 @@
     },
     {
         "instrument": "IRC",
-        "mode": "Missing",
-        "telescope": "AKARI",
-        "description": null,
-        "reference": null
-    },
-    {
-        "instrument": "IRC",
         "mode": "NIR",
         "telescope": "AKARI",
         "description": null,
-        "reference": null
-    },
-    {
-        "instrument": "LRIS",
-        "mode": "Missing",
-        "telescope": "KECK I",
-        "description": null,
-        "reference": null
+        "reference": "Mura07"
     }
 ]

--- a/data/reference/Publications.json
+++ b/data/reference/Publications.json
@@ -7319,10 +7319,4 @@
         "doi": "10.1086/670241",
         "description": null
     },
-    {
-        "reference": "Burg03",
-        "bibcode": "2003ApJ...594..510B",
-        "doi": "10.1086/376756",
-        "description": null
-    }
 ]

--- a/data/reference/Publications.json
+++ b/data/reference/Publications.json
@@ -7306,5 +7306,23 @@
         "bibcode": "2024AJ....167..253R",
         "doi": "10.3847/1538-3881/ad324e",
         "description": "89 New Ultracool Dwarf Comoving Companions Identified with the Backyard Worlds: Planet 9 Citizen Science Project"
+    },
+    {
+        "reference": "Sora12",
+        "bibcode": "2012ApJ...760..151S",
+        "doi": "10.1088/0004-637X/760/1/6",
+        "description": null
+    },
+    {
+        "reference": "Simc13",
+        "bibcode": "2013PASP..125..270S",
+        "doi": "10.1086/670241",
+        "description": null
+    },
+    {
+        "reference": "Burg03",
+        "bibcode": "2003ApJ...594..510B",
+        "doi": "10.1086/376756",
+        "description": null
     }
 ]

--- a/data/reference/Publications.json
+++ b/data/reference/Publications.json
@@ -7324,5 +7324,11 @@
         "bibcode": "2007PASJ...59S.369M",
         "doi": "10.1093/pasj/59.sp2.S369",
         "description": "The Infrared Astronomical Mission AKARI*"
+    },
+    {
+        "reference": "Onak07",
+        "bibcode": "2007PASJ...59S.401O",
+        "doi": "10.1093/pasj/59.sp2.S401",
+        "description": "The Infrared Camera (IRC) for AKARI -- Design and Imaging Performance"
     }
 ]

--- a/data/reference/Publications.json
+++ b/data/reference/Publications.json
@@ -7310,13 +7310,19 @@
     {
         "reference": "Sora12",
         "bibcode": "2012ApJ...760..151S",
-        "doi": "10.1088/0004-637X/760/1/6",
-        "description": null
+        "doi": "10.1088/0004-637X/760/2/151",
+        "description": "AKARI Observations of Brown Dwarfs. III. CO, CO<SUB>2</SUB>, and CH<SUB>4</SUB> Fundamental Bands and Physical Parameters"
     },
     {
         "reference": "Simc13",
         "bibcode": "2013PASP..125..270S",
         "doi": "10.1086/670241",
-        "description": null
+        "description": "FIRE: A Facility Class Near-Infrared Echelle Spectrometer for the Magellan Telescopes"
     },
+    {
+        "reference": "Mura07",
+        "bibcode": "2007PASJ...59S.369M",
+        "doi": "10.1093/pasj/59.sp2.S369",
+        "description": "The Infrared Astronomical Mission AKARI*"
+    }
 ]

--- a/data/reference/Telescopes.json
+++ b/data/reference/Telescopes.json
@@ -192,6 +192,6 @@
     {
         "telescope": "AKARI",
         "description": null,
-        "reference": null
+        "reference": "Mura07"
     }
 ]

--- a/data/reference/Telescopes.json
+++ b/data/reference/Telescopes.json
@@ -194,9 +194,4 @@
         "description": null,
         "reference": null
     },
-    {
-        "telescope": "KECK I",
-        "description": null,
-        "reference": null
-    }
 ]

--- a/data/reference/Telescopes.json
+++ b/data/reference/Telescopes.json
@@ -188,5 +188,15 @@
         "telescope": "LCO",
         "description": null,
         "reference": null
+    },
+    {
+        "telescope": "AKARI",
+        "description": null,
+        "reference": null
+    },
+    {
+        "telescope": "KECK I",
+        "description": null,
+        "reference": null
     }
 ]

--- a/data/reference/Telescopes.json
+++ b/data/reference/Telescopes.json
@@ -193,5 +193,5 @@
         "telescope": "AKARI",
         "description": null,
         "reference": null
-    },
+    }
 ]

--- a/data/source/2mass_j04151954-0935066.json
+++ b/data/source/2mass_j04151954-0935066.json
@@ -361,12 +361,12 @@
             "original_spectrum": null,
             "local_spectrum": null,
             "regime": "nir",
-            "telescope": "KECK I",
+            "telescope": "Keck I",
             "instrument": "LRIS",
             "mode": "Missing",
             "observation_date": "2001-02-20T00:00:00",
-            "comments": "The Spectra of T Dwarfs. II. Red Optical Data",
-            "reference": "Burg03",
+            "comments": null,
+            "reference": "Burg03.510",
             "other_references": null
         },
         {
@@ -387,11 +387,11 @@
             "original_spectrum": null,
             "local_spectrum": null,
             "regime": "nir",
-            "telescope": "KECK I",
+            "telescope": "Keck I",
             "instrument": "LRIS",
             "mode": "Missing",
             "observation_date": "2006-12-26T00:00:00",
-            "comments": "A Sample of Very Young Field L Dwarfs and Implications for the Brown Dwarf 'Lithium Test' at Early Ages",
+            "comments": null,
             "reference": "Kirk08",
             "other_references": null
         },
@@ -404,7 +404,7 @@
             "instrument": "IRC",
             "mode": "NIR",
             "observation_date": "2007-08-23T00:00:00",
-            "comments": "AKARI Observations of Brown Dwarfs. III. CO, CO2, and CH4 Fundamental Bands and Physical Parameters",
+            "comments": null,
             "reference": "Sora12",
             "other_references": null
         },
@@ -417,7 +417,7 @@
             "instrument": "FIRE",
             "mode": "Echelle",
             "observation_date": "2010-09-20T00:00:00",
-            "comments": "FIRE: A Facility Class Near-Infrared Echelle Spectrometer for the Magellan Telescopes",
+            "comments": null,
             "reference": "Simc13",
             "other_references": null
         }

--- a/data/source/2mass_j04151954-0935066.json
+++ b/data/source/2mass_j04151954-0935066.json
@@ -357,19 +357,6 @@
             "other_references": null
         },
         {
-            "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASSJ04151954-0935066_T8_LRIS_Burg03.fits",
-            "original_spectrum": null,
-            "local_spectrum": null,
-            "regime": "nir",
-            "telescope": "Keck I",
-            "instrument": "LRIS",
-            "mode": "Missing",
-            "observation_date": "2001-02-20T00:00:00",
-            "comments": null,
-            "reference": "Burg03.510",
-            "other_references": null
-        },
-        {
             "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/SpeX/Prism/IRTF_SpeX_2MASS%2BJ04151954-0935066_2003-09-17.fits",
             "original_spectrum": "https://s3.amazonaws.com/bdnyc/spex-prism_2MASSIJ0415195-093506_20030917_BUR04B.txt",
             "local_spectrum": "$BDNYC_spectra/SpeX/Prism/spex-prism_2MASSIJ0415195-093506_20030917_BUR04B.txt",
@@ -383,26 +370,13 @@
             "other_references": null
         },
         {
-            "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASS_J04151954-0935066_2006-12-26.fits",
-            "original_spectrum": null,
-            "local_spectrum": null,
-            "regime": "nir",
-            "telescope": "Keck I",
-            "instrument": "LRIS",
-            "mode": "Missing",
-            "observation_date": "2006-12-26T00:00:00",
-            "comments": null,
-            "reference": "Kirk08",
-            "other_references": null
-        },
-        {
             "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/AKARI_2MASS%2BJ04151954-0935066_2007-08-23.fits",
             "original_spectrum": null,
             "local_spectrum": null,
             "regime": "nir",
             "telescope": "AKARI",
             "instrument": "IRC",
-            "mode": "NIR",
+            "mode": "IRC04",
             "observation_date": "2007-08-23T00:00:00",
             "comments": null,
             "reference": "Sora12",
@@ -419,6 +393,32 @@
             "observation_date": "2010-09-20T00:00:00",
             "comments": null,
             "reference": "Simc13",
+            "other_references": null
+        },
+        {
+            "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASSJ04151954-0935066_T8_LRIS_Burg03.fits",
+            "original_spectrum": null,
+            "local_spectrum": null,
+            "regime": "optical",
+            "telescope": "Keck I",
+            "instrument": "LRIS",
+            "mode": "Missing",
+            "observation_date": "2001-02-20T00:00:00",
+            "comments": null,
+            "reference": "Burg03.510",
+            "other_references": null
+        },
+        {
+            "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASS_J04151954-0935066_2006-12-26.fits",
+            "original_spectrum": null,
+            "local_spectrum": null,
+            "regime": "optical",
+            "telescope": "Keck I",
+            "instrument": "LRIS",
+            "mode": "Missing",
+            "observation_date": "2006-12-26T00:00:00",
+            "comments": null,
+            "reference": "Kirk08",
             "other_references": null
         }
     ],

--- a/data/source/2mass_j04151954-0935066.json
+++ b/data/source/2mass_j04151954-0935066.json
@@ -357,8 +357,21 @@
             "other_references": null
         },
         {
-            "access_url": "https://s3.amazonaws.com/bdnyc/spex-prism_2MASSIJ0415195-093506_20030917_BUR04B.txt",
+            "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASSJ04151954-0935066_T8_LRIS_Burg03.fits",
             "original_spectrum": null,
+            "local_spectrum": null,
+            "regime": "nir",
+            "telescope": "KECK I",
+            "instrument": "LRIS",
+            "mode": "Missing",
+            "observation_date": "2001-02-20T00:00:00",
+            "comments": "The Spectra of T Dwarfs. II. Red Optical Data",
+            "reference": "Burg03",
+            "other_references": null
+        },
+        {
+            "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/SpeX/Prism/IRTF_SpeX_2MASS%2BJ04151954-0935066_2003-09-17.fits",
+            "original_spectrum": "https://s3.amazonaws.com/bdnyc/spex-prism_2MASSIJ0415195-093506_20030917_BUR04B.txt",
             "local_spectrum": "$BDNYC_spectra/SpeX/Prism/spex-prism_2MASSIJ0415195-093506_20030917_BUR04B.txt",
             "regime": "nir",
             "telescope": "IRTF",
@@ -367,6 +380,45 @@
             "observation_date": "2003-09-17T00:00:00",
             "comments": null,
             "reference": "Burg04.2856",
+            "other_references": null
+        },
+        {
+            "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASS_J04151954-0935066_2006-12-26.fits",
+            "original_spectrum": null,
+            "local_spectrum": null,
+            "regime": "nir",
+            "telescope": "KECK I",
+            "instrument": "LRIS",
+            "mode": "Missing",
+            "observation_date": "2006-12-26T00:00:00",
+            "comments": "A Sample of Very Young Field L Dwarfs and Implications for the Brown Dwarf 'Lithium Test' at Early Ages",
+            "reference": "Kirk08",
+            "other_references": null
+        },
+        {
+            "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/AKARI_2MASS%2BJ04151954-0935066_2007-08-23.fits",
+            "original_spectrum": null,
+            "local_spectrum": null,
+            "regime": "nir",
+            "telescope": "AKARI",
+            "instrument": "IRC",
+            "mode": "NIR",
+            "observation_date": "2007-08-23T00:00:00",
+            "comments": "AKARI Observations of Brown Dwarfs. III. CO, CO2, and CH4 Fundamental Bands and Physical Parameters",
+            "reference": "Sora12",
+            "other_references": null
+        },
+        {
+            "access_url": "https://bdnyc.s3.us-east-1.amazonaws.com/FIRE/FIRE_0415-0935.fits",
+            "original_spectrum": null,
+            "local_spectrum": null,
+            "regime": "nir",
+            "telescope": "Magellan I Baade",
+            "instrument": "FIRE",
+            "mode": "Echelle",
+            "observation_date": "2010-09-20T00:00:00",
+            "comments": "FIRE: A Facility Class Near-Infrared Echelle Spectrometer for the Magellan Telescopes",
+            "reference": "Simc13",
             "other_references": null
         }
     ],

--- a/scripts/ingests/Ingest_2MASS_J0415_09.py
+++ b/scripts/ingests/Ingest_2MASS_J0415_09.py
@@ -1,0 +1,119 @@
+"""
+
+Data to be Ingested:
+- Akari Spectrum
+- FIRE Magellan Spectrum 
+- KECK LRIS Spectrum Burg '03
+- Keck LRIS Spectrum Kirk '08
+
+Key Functions:
+- Ingest_Spectra, Ingest Publication, Ingest Instrument
+
+"""
+
+from astrodb_utils import * # load_astrodb, ingest_instrument, ingest_publication, find_publication
+from simple.utils.spectra import * # ingest_spectrum
+from simple.schema import Spectra
+from simple.schema import *
+from simple.schema import REFERENCE_TABLES
+
+#Load in Database
+db = load_astrodb("SIMPLE.sqlite", recreatedb=True, reference_tables=REFERENCE_TABLES)
+
+#Dictionary of new spectra
+spectras = [
+
+    {
+        "file": "https://bdnyc.s3.us-east-1.amazonaws.com/AKARI_2MASS%2BJ04151954-0935066_2007-08-23.fits",
+        "source": "2MASS J04151954-0935066",
+        "regime": "nir",
+        "telescope": "AKARI",
+        "instrument": "IRC",
+        "mode": "NIR",
+        "obs_date": "2007-08-23",
+        "reference": "Sora12",
+        "bibcode": "2012ApJ...760..151S", 
+        "comments":"AKARI Observations of Brown Dwarfs. III. CO, CO2, and CH4 Fundamental Bands and Physical Parameters",
+        "doi": "10.1088/0004-637X/760/1/6",
+
+    },
+    {
+        "file": "https://bdnyc.s3.us-east-1.amazonaws.com/FIRE/FIRE_0415-0935.fits",
+        "source": "2MASS J04151954-0935066",
+        "regime": "nir",
+        "telescope": "Magellan I Baade",
+        "instrument": "FIRE",
+        "mode": "Echelle",
+        "obs_date": "2010-09-20",
+        "reference": "Simc13",
+        "comments": "FIRE: A Facility Class Near-Infrared Echelle Spectrometer for the Magellan Telescopes", 
+        "bibcode": "2013PASP..125..270S", 
+        "doi": "10.1086/670241",
+    },
+    {
+        "file": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASSJ04151954-0935066_T8_LRIS_Burg03.fits",
+        "source": "2MASS J04151954-0935066",
+        "regime": "nir",
+        "telescope": "KECK I",
+        "instrument": "LRIS",
+        "mode": "Missing",
+        "obs_date": "2001-02-20",
+        "reference": "Burg03",
+        "comments": "The Spectra of T Dwarfs. II. Red Optical Data",
+        "bibcode": "2003ApJ...594..510B", 
+        "doi": "10.1086/376756",
+
+    },
+    {
+        "file": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASS_J04151954-0935066_2006-12-26.fits",
+        "source": "2MASS J04151954-0935066",
+        "regime": "nir",
+        "telescope": "KECK I",
+        "instrument": "LRIS",
+        "mode": "Missing",
+        "obs_date": "2006-12-26",
+        "reference": "Kirk08",
+        "comments": "A Sample of Very Young Field L Dwarfs and Implications for the Brown Dwarf 'Lithium Test' at Early Ages",
+        "bibcode": "2008ApJ...689.1295K", 
+        "doi": "10.1086/592768",
+    }
+]
+
+
+#Ingest data
+for spectrum in spectras:
+    
+    ingest_instrument(
+        db,
+        telescope=spectrum["telescope"],
+        instrument=spectrum["instrument"],
+        mode=spectrum["mode"],
+    )
+
+    status, details = find_publication(db, reference=spectrum["reference"])
+    if status == False:
+        ingest_publication(
+            db,
+            reference=spectrum["reference"],
+            bibcode=spectrum['bibcode'],
+            doi=spectrum['doi'],
+            ignore_ads=True,
+        )
+
+
+    ingest_spectrum(
+        db,
+        source=spectrum["source"],
+        spectrum=spectrum["file"],
+        regime=spectrum["regime"],
+        telescope=spectrum["telescope"],
+        instrument=spectrum["instrument"],
+        mode=spectrum["mode"],
+        obs_date=spectrum["obs_date"],
+        reference=spectrum["reference"],
+        comments=spectrum['comments']
+
+    )
+
+# Save to Database
+db.save_database(directory="data/")

--- a/scripts/ingests/Ingest_2MASS_J0415_09.py
+++ b/scripts/ingests/Ingest_2MASS_J0415_09.py
@@ -11,8 +11,8 @@ Key Functions:
 
 """
 
-from astrodb_utils import * # load_astrodb, ingest_instrument, ingest_publication, find_publication
-from simple.utils.spectra import * # ingest_spectrum
+from astrodb_utils import * 
+from simple.utils.spectra import * 
 from simple.schema import Spectra
 from simple.schema import *
 from simple.schema import REFERENCE_TABLES
@@ -20,95 +20,72 @@ from simple.schema import REFERENCE_TABLES
 #Load in Database
 db = load_astrodb("SIMPLE.sqlite", recreatedb=True, reference_tables=REFERENCE_TABLES)
 
-#Dictionary of new spectra
-spectras = [
-
-    {
-        "file": "https://bdnyc.s3.us-east-1.amazonaws.com/AKARI_2MASS%2BJ04151954-0935066_2007-08-23.fits",
-        "source": "2MASS J04151954-0935066",
-        "regime": "nir",
-        "telescope": "AKARI",
-        "instrument": "IRC",
-        "mode": "NIR",
-        "obs_date": "2007-08-23",
-        "bibcode": "2012ApJ...760..151S", 
-
-    },
-    {
-        "file": "https://bdnyc.s3.us-east-1.amazonaws.com/FIRE/FIRE_0415-0935.fits",
-        "source": "2MASS J04151954-0935066",
-        "regime": "nir",
-        "telescope": "Magellan I Baade",
-        "instrument": "FIRE",
-        "mode": "Echelle",
-        "obs_date": "2010-09-20",
-        "reference": "Simc13",
-        "bibcode": "2013PASP..125..270S", 
-    },
-    {
-        "file": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASSJ04151954-0935066_T8_LRIS_Burg03.fits",
-        "source": "2MASS J04151954-0935066",
-        "regime": "nir",
-        "telescope": "KECK I",
-        "instrument": "LRIS",
-        "mode": "Missing",
-        "obs_date": "2001-02-20",
-        "reference": "Burg03",
-        "comments": "The Spectra of T Dwarfs. II. Red Optical Data",
-        "bibcode": "2003ApJ...594..510B", 
-        "doi": "10.1086/376756",
-
-    },
-    {
-        "file": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASS_J04151954-0935066_2006-12-26.fits",
-        "source": "2MASS J04151954-0935066",
-        "regime": "nir",
-        "telescope": "KECK I",
-        "instrument": "LRIS",
-        "mode": "Missing",
-        "obs_date": "2006-12-26",
-        "reference": "Kirk08",
-        "comments": "A Sample of Very Young Field L Dwarfs and Implications for the Brown Dwarf 'Lithium Test' at Early Ages",
-        "bibcode": "2008ApJ...689.1295K", 
-        "doi": "10.1086/592768",
-    }
-]
-
-
 #Ingest data
-for spectrum in spectras:
-    
-    ingest_instrument(
-        db,
-        telescope=spectrum["telescope"],
-        instrument=spectrum["instrument"],
-        mode=spectrum["mode"],
-    )
+ingest_publication(
+    db, 
+    bibcode = "2012ApJ...760..151S"
+)
 
-    status, details = find_publication(db, reference=spectrum["reference"])
-    if status == False:
-        ingest_publication(
-            db,
-            reference=spectrum["reference"],
-            bibcode=spectrum['bibcode'],
-            doi=spectrum['doi'],
-            ignore_ads=True,
-        )
+ingest_publication(
+    db, 
+    bibcode = "2013PASP..125..270S"
+)
 
+ingest_publication(
+    db, 
+    bibcode="2007PASJ...59S.369M"
+)
 
-    ingest_spectrum(
-        db,
-        source=spectrum["source"],
-        spectrum=spectrum["file"],
-        regime=spectrum["regime"],
-        telescope=spectrum["telescope"],
-        instrument=spectrum["instrument"],
-        mode=spectrum["mode"],
-        obs_date=spectrum["obs_date"],
-        reference=spectrum["reference"],
-        comments=spectrum['comments']
+ingest_spectrum(
+    db,
+    source="2MASS J04151954-0935066",
+    spectrum="https://bdnyc.s3.us-east-1.amazonaws.com/AKARI_2MASS%2BJ04151954-0935066_2007-08-23.fits",
+    regime="nir",
+    telescope="AKARI",
+    instrument="IRC",
+    mode="NIR",
+    obs_date="2007-08-23",
+    reference="Sora12"
 
-    )
+)
+
+ingest_spectrum(
+    db,
+    source="2MASS J04151954-0935066",
+    spectrum="https://bdnyc.s3.us-east-1.amazonaws.com/FIRE/FIRE_0415-0935.fits",
+    regime="nir",
+    telescope="Magellan I Baade",
+    instrument="FIRE",
+    mode="Echelle",
+    obs_date="2010-09-20",
+    reference="Simc13"
+
+)
+
+ingest_spectrum(
+    db,
+    source="2MASS J04151954-0935066",
+    spectrum="https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASS_J04151954-0935066_2006-12-26.fits",
+    regime="nir",
+    instrument="LRIS",
+    telescope="Keck I",
+    mode="Missing",
+    obs_date="2006-12-26",
+    reference="Kirk08"
+)
+
+ingest_spectrum(
+    db,
+    source="2MASS J04151954-0935066",
+    spectrum="https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASSJ04151954-0935066_T8_LRIS_Burg03.fits",
+    regime="nir",
+    instrument="LRIS",
+    telescope="Keck I",
+    mode="Missing",
+    obs_date="2001-02-20",
+    reference="Burg03.510"
+)
+
 
 # Save to Database
 db.save_database(directory="data/")

--- a/scripts/ingests/Ingest_2MASS_J0415_09.py
+++ b/scripts/ingests/Ingest_2MASS_J0415_09.py
@@ -20,7 +20,7 @@ from simple.schema import REFERENCE_TABLES
 #Load in Database
 db = load_astrodb("SIMPLE.sqlite", recreatedb=True, reference_tables=REFERENCE_TABLES)
 
-Ingest data
+# Ingest data
 ingest_publication(
     db, 
     bibcode = "2012ApJ...760..151S"

--- a/scripts/ingests/Ingest_2MASS_J0415_09.py
+++ b/scripts/ingests/Ingest_2MASS_J0415_09.py
@@ -31,10 +31,7 @@ spectras = [
         "instrument": "IRC",
         "mode": "NIR",
         "obs_date": "2007-08-23",
-        "reference": "Sora12",
         "bibcode": "2012ApJ...760..151S", 
-        "comments":"AKARI Observations of Brown Dwarfs. III. CO, CO2, and CH4 Fundamental Bands and Physical Parameters",
-        "doi": "10.1088/0004-637X/760/1/6",
 
     },
     {

--- a/scripts/ingests/Ingest_2MASS_J0415_09.py
+++ b/scripts/ingests/Ingest_2MASS_J0415_09.py
@@ -46,9 +46,7 @@ spectras = [
         "mode": "Echelle",
         "obs_date": "2010-09-20",
         "reference": "Simc13",
-        "comments": "FIRE: A Facility Class Near-Infrared Echelle Spectrometer for the Magellan Telescopes", 
         "bibcode": "2013PASP..125..270S", 
-        "doi": "10.1086/670241",
     },
     {
         "file": "https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASSJ04151954-0935066_T8_LRIS_Burg03.fits",

--- a/scripts/ingests/Ingest_2MASS_J0415_09.py
+++ b/scripts/ingests/Ingest_2MASS_J0415_09.py
@@ -20,7 +20,7 @@ from simple.schema import REFERENCE_TABLES
 #Load in Database
 db = load_astrodb("SIMPLE.sqlite", recreatedb=True, reference_tables=REFERENCE_TABLES)
 
-#Ingest data
+Ingest data
 ingest_publication(
     db, 
     bibcode = "2012ApJ...760..151S"
@@ -36,6 +36,11 @@ ingest_publication(
     bibcode="2007PASJ...59S.369M"
 )
 
+ingest_publication(
+    db,
+    bibcode = "2007PASJ...59S.401O"
+)
+
 ingest_spectrum(
     db,
     source="2MASS J04151954-0935066",
@@ -43,7 +48,7 @@ ingest_spectrum(
     regime="nir",
     telescope="AKARI",
     instrument="IRC",
-    mode="NIR",
+    mode="IRC04",
     obs_date="2007-08-23",
     reference="Sora12"
 
@@ -66,7 +71,7 @@ ingest_spectrum(
     db,
     source="2MASS J04151954-0935066",
     spectrum="https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASS_J04151954-0935066_2006-12-26.fits",
-    regime="nir",
+    regime="optical",
     instrument="LRIS",
     telescope="Keck I",
     mode="Missing",
@@ -78,7 +83,7 @@ ingest_spectrum(
     db,
     source="2MASS J04151954-0935066",
     spectrum="https://bdnyc.s3.us-east-1.amazonaws.com/LRIS/KECK_LRIS_2MASSJ04151954-0935066_T8_LRIS_Burg03.fits",
-    regime="nir",
+    regime="optical",
     instrument="LRIS",
     telescope="Keck I",
     mode="Missing",

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -242,11 +242,11 @@ def test_missions(db):
 def test_spectra(db):
     regime = "optical"
     t = db.query(db.Spectra).filter(db.Spectra.c.regime == regime).astropy()
-    assert len(t) == 740, f"found {len(t)} spectra in the {regime} regime"
+    assert len(t) == 742, f"found {len(t)} spectra in the {regime} regime"
 
     regime = "nir"
     t = db.query(db.Spectra).filter(db.Spectra.c.regime == regime).astropy()
-    assert len(t) == 582, f"found {len(t)} spectra in the {regime} regime"
+    assert len(t) == 580, f"found {len(t)} spectra in the {regime} regime"
 
     regime = "mir"
     t = db.query(db.Spectra).filter(db.Spectra.c.regime == regime).astropy()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -246,7 +246,7 @@ def test_spectra(db):
 
     regime = "nir"
     t = db.query(db.Spectra).filter(db.Spectra.c.regime == regime).astropy()
-    assert len(t) == 578, f"found {len(t)} spectra in the {regime} regime"
+    assert len(t) == 582, f"found {len(t)} spectra in the {regime} regime"
 
     regime = "mir"
     t = db.query(db.Spectra).filter(db.Spectra.c.regime == regime).astropy()


### PR DESCRIPTION
Short description: Ingest of 2MASS 0415-09. Updates the Burg03 IRTF data within the JSON file, adds the AKARI (Sora12), FIRE (Simc13), KECK I LRIS (Burg04), and KECK I LRIS (Kirk08) data using a new script. 
 

Link to relevant issue: Closes #559 & #375 

For data ingests:
[x] includes script used for ingest
[x ] includes modified JSON files
[ ] Add new tests
[ ] Update the Versions table
