### PR TITLE
Fix for generate DB workflow

### DIFF
--- a/.github/workflows/gen-db.yml
+++ b/.github/workflows/gen-db.yml
@@ -31,6 +31,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install astrodbkit
         pip install astrodb_utils
+        pip install .
 
     - name: Generate sqlite (file) database
       run: |


### PR DESCRIPTION
Fixes generate DB workflow by explicitly pip installing the package.

Closes #567 
