### PR TITLE
Test more Python versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,14 +12,17 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version:  ${{ matrix.python-version }}
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version:  ${{ matrix.python-version }}
+        cache: 'pip'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Current tests only test Python 3.10.  We want to start using Felis which requires at least Python 3.11.  This PR expands our testing matrix.  Closes #563 .