### PR TITLE
Fix W1049 system names

### DIFF
--- a/data/source/wise_j104915.57-531906.1.json
+++ b/data/source/wise_j104915.57-531906.1.json
@@ -14,16 +14,16 @@
     ],
     "CompanionRelationships": [
         {
-            "companion_name": "WISE J104915.57-531906.1A",
+            "companion_name": "WISE J1049-5319A",
             "relationship": "Parent",
             "reference": "Luhm13",
-            "other_companion_names": "WISE J104915.57-531906.1A"
+            "other_companion_names": "Luhman 16A"
         },
         {
-            "companion_name": "WISE J104915.57-531906.1B",
+            "companion_name": "WISE J1049-5319B",
             "relationship": "Parent",
             "reference": "Luhm13",
-            "other_companion_names": "WISE J104915.57-531906.1B"
+            "other_companion_names": "Luhman 16B"
         }
     ],
     "Names": [

--- a/data/source/wise_j104915.57-531906.1A.json
+++ b/data/source/wise_j104915.57-531906.1A.json
@@ -1,7 +1,7 @@
 {
     "Sources": [
         {
-            "source": "WISE J104915.57-531906.1A",
+            "source": "WISE J1049-5319A",
             "ra": 162.329,
             "dec": -53.3194,
             "epoch": 2000.0,
@@ -17,13 +17,13 @@
             "companion_name": "WISE J104915.57-531906.1",
             "relationship": "Child",
             "reference": "Luhm13",
-            "other_companion_names": "WISE J104915.57-531906.1"
+            "other_companion_names": null
         },
         {
-            "companion_name": "WISE J104915.57-531906.1B",
+            "companion_name": "WISE J1049-5319B",
             "relationship": "Sibling",
             "reference": "Luhm13",
-            "other_companion_names": "WISE J104915.57-531906.1B"
+            "other_companion_names": "Luhman 16B"
         }
     ],
     "ModeledParameters": [
@@ -68,7 +68,10 @@
             "other_name": "NAME Luhman 16A"
         },
         {
-            "other_name": "WISE J104915.57-531906.1A"
+            "other_name": "WISE J1049-5319A"
+        },
+        {
+            "other_name": "Gaia DR2 5353626573555863424"
         }
     ],
     "Spectra": [

--- a/data/source/wise_j104915.57-531906.1B.json
+++ b/data/source/wise_j104915.57-531906.1B.json
@@ -1,7 +1,7 @@
 {
     "Sources": [
         {
-            "source": "WISE J104915.57-531906.1B",
+            "source": "WISE J1049-5319B",
             "ra": 162.329,
             "dec": -53.3192,
             "epoch": 2000.0,
@@ -20,10 +20,10 @@
             "other_companion_names": "WISE J104915.57-531906.1"
         },
         {
-            "companion_name": "WISE J104915.57-531906.1A",
+            "companion_name": "WISE J1049-5319A",
             "relationship": "Sibling",
             "reference": "Luhm13",
-            "other_companion_names": "WISE J104915.57-531906.1A"
+            "other_companion_names": "Luhman 16A"
         }
     ],
     "ModeledParameters": [
@@ -68,7 +68,7 @@
             "other_name": "NAME Luhman 16B"
         },
         {
-            "other_name": "WISE J104915.57-531906.1B"
+            "other_name": "WISE J1049-5319B"
         }
     ],
     "Spectra": [

--- a/tests/scheduled_checks.py
+++ b/tests/scheduled_checks.py
@@ -93,16 +93,17 @@ def test_source_simbad(db):
             )
             duplicate_count += 1
 
-    assert duplicate_count == 0, "Duplicate sources identified via Simbad queries"
-
-    # with open("not_in_simbad.txt", "w") as f:
+    # Write not_in_simbad list to file
+    # with open("tests/not_in_simbad_25Jul1.txt", "w") as f:
     #    f.write("\n".join(not_in_simbad))
 
+    assert duplicate_count == 0, "Duplicate sources identified via Simbad queries"
+
     assert (
-        len(not_in_simbad) == 371
+        len(not_in_simbad) == 370
     ), f"Expecting {len(not_in_simbad)} sources not found in Simbad"
 
-    assert len(in_simbad) == 3227, "Sources found in Simbad"
+    assert len(in_simbad) == 3228, "Sources found in Simbad"
     print(f"Found {len(in_simbad)} SIMPLE sources in Simbad")
 
     assert len(not_in_simbad) + len(in_simbad) == len(

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -19,7 +19,7 @@ def test_sources(db):
     assert n_sources == 3598, f"found {n_sources} sources"
 
     n_names = db.query(db.Names).count()
-    assert n_names == 9172, f"found {n_names} names"
+    assert n_names == 9173, f"found {n_names} names"
 
 
 @pytest.mark.parametrize(
@@ -98,7 +98,7 @@ def test_missions(db):
     )
     s = db.session.scalars(stm).all()
     assert (
-        len(s) == 10
+        len(s) == 11
     ), f"found {len(s)} sources with Gaia designation that have no GAIA photometry"
 
     # If Gaia photometry, Gaia designation should be in Names


### PR DESCRIPTION
We changed the names of these objects but unfortunately, they were not resolvable by SIMBAD. This PR changes those names to be recognized by SIMBAD.  Also updates the scheduled tests to know how many names to expect.  Issue #585 already updated with these changes.