### PR TITLE
Update 2mass_j00001354+2554180.json - fix discovery reference.

### DIFF
--- a/data/source/2mass_j00001354+2554180.json
+++ b/data/source/2mass_j00001354+2554180.json
@@ -7,7 +7,7 @@
             "epoch": null,
             "equinox": null,
             "shortname": "0000+2554",
-            "reference": "Knap04",
+            "reference": "Burg04",
             "other_references": null,
             "comments": null
         }


### PR DESCRIPTION
was a typo in BONES archive.

easy fix of incorrect discovery ref.

